### PR TITLE
feat(compiler): add warning for empty enum

### DIFF
--- a/compilation.md
+++ b/compilation.md
@@ -99,6 +99,8 @@ Any Thrift compiler messages should be detailed in this section.
 
 ### TC0000 - Enum Must Have a Name
 
+_Level_: Error
+
 Reported when an enum is defined with no name specified, for example:
 
 ```thrift
@@ -118,6 +120,8 @@ enum UserType {
 ```
 
 ### TC0001 - Enum Member Must Have a Name
+
+_Level_: Error
 
 An enum member has been defined without a name, for example:
 
@@ -139,6 +143,8 @@ enum UserType {
 
 ### TC0002 - Enum Value Must Not Be Negative
 
+_Level_: Error
+
 An enum member has been specified with a negative value. For example:
 
 ```thrift
@@ -159,6 +165,8 @@ enum UserType {
 
 ### TC0003 - Enum Value Must Be an Integer
 
+_Level_: Error
+
 An enum value has been specified that isn't an integer. For example:
 
 ```thrift
@@ -178,6 +186,8 @@ enum UserType {
 ```
 
 ### TC0004 - Enum Value Must Be Specified
+
+_Level_: Error
 
 An enum member has been defined but the value is missing from the assign
 expression. For example:
@@ -206,6 +216,8 @@ enum UserType {
 
 ### TC0005 - Enum Member Equals Operator Missing
 
+_Level_: Error
+
 The equals operator is missing between an enum member and its value. For
 example:
 
@@ -223,7 +235,28 @@ enum UserType {
 }
 ```
 
-### TC0006 - Namespace Scope Unknown
+### TC0006 - Enum Has No Members
+
+_Level_: Warning
+
+An enum has been defined with no members. For example:
+
+```thrift
+enum UserType {
+}
+```
+
+To fix this issue add at least one enum member:
+
+```thrift
+enum UserType {
+  User = 0
+}
+```
+
+### TC0100 - Namespace Scope Unknown
+
+_Level_: Error
 
 The specified namespace scope is not in the list of known namespaces. For
 example:
@@ -238,7 +271,9 @@ To fix this issue change the scope to a valid language target:
 namespace csharp Thrift.Net.Examples
 ```
 
-### TC0007 - Namespace Scope Missing
+### TC0101 - Namespace Scope Missing
+
+_Level_: Error
 
 A namespace has been specified without a scope. For example
 
@@ -252,7 +287,9 @@ To fix this issue add a scope:
 namespace csharp Thrift.Net.Examples
 ```
 
-### TC0008 - Namespace and Scope Missing
+### TC0102 - Namespace and Scope Missing
+
+_Level_: Error
 
 The namespace keyword has been specified, but without a scope or namespace being
 provided. For example:
@@ -267,7 +304,9 @@ To fix this issue provide a scope and namespace:
 namespace csharp Thrift.Net.Examples
 ```
 
-### TC0009 - Namespace Missing
+### TC0103 - Namespace Missing
+
+_Level_: Error
 
 A namespace scope has been specified without a corresponding namespace being
 provided. For example:

--- a/src/Thrift.Net.Antlr/Thrift.g4
+++ b/src/Thrift.Net.Antlr/Thrift.g4
@@ -12,8 +12,7 @@ definitions: definition*;
 
 definition: enumDefinition;
 
-// TODO: Warning for empty enum
-enumDefinition: ENUM IDENTIFIER?
+enumDefinition: ENUM name=IDENTIFIER?
     '{'
         enumMember*
     '}';

--- a/src/Thrift.Net.Compilation/CompilationVisitor.cs
+++ b/src/Thrift.Net.Compilation/CompilationVisitor.cs
@@ -133,6 +133,20 @@ namespace Thrift.Net.Compilation
 
             this.enums.Add(new EnumDefinition(name, members.ToList()));
 
+            if (!members.Any())
+            {
+                var warningTarget = context.name ?? context.ENUM().Symbol;
+
+                // The enum has no members. For example
+                // `enum MyEnum {}`
+                this.messages.Add(new CompilationMessage(
+                    CompilerMessageId.EnumEmpty,
+                    CompilerMessageType.Warning,
+                    warningTarget.Line,
+                    warningTarget.Column + 1,
+                    warningTarget.Column + warningTarget.Text.Length));
+            }
+
             return result;
         }
 
@@ -185,9 +199,9 @@ namespace Thrift.Net.Compilation
 
         private string GetEnumName(ThriftParser.EnumDefinitionContext context)
         {
-            if (context.IDENTIFIER() != null)
+            if (context.name != null)
             {
-                return context.IDENTIFIER().Symbol.Text;
+                return context.name.Text;
             }
 
             // The enum name is missing: `enum {}`.

--- a/src/Thrift.Net.Compilation/CompilerMessageId.cs
+++ b/src/Thrift.Net.Compilation/CompilerMessageId.cs
@@ -42,27 +42,33 @@ namespace Thrift.Net.Compilation
         EnumMemberEqualsOperatorMissing = 5,
 
         /// <summary>
+        /// An enum has been defined with no members. For example
+        /// `enum MyEnum {}`.
+        /// </summary>
+        EnumEmpty = 6,
+
+        /// <summary>
         /// The specified namespace scope is not in the list of known namespaces.
         /// For example `namespace notalang mynamespace`.
         /// </summary>
-        NamespaceScopeUnknown = 6,
+        NamespaceScopeUnknown = 100,
 
         /// <summary>
         /// A namespace has been specified without a scope. For example
         /// `namespace mynamespace`.
         /// </summary>
-        NamespaceScopeMissing = 7,
+        NamespaceScopeMissing = 101,
 
         /// <summary>
         /// The namespace keyword has been specified, but without a scope or
         /// namespace being provided. For example `namespace`.
         /// </summary>
-        NamespaceAndScopeMissing = 8,
+        NamespaceAndScopeMissing = 102,
 
         /// <summary>
         /// A namespace scope has been specified without a corresponding
         /// namespace being provided. For example `namespace csharp`.
         /// </summary>
-        NamespaceMissing = 9,
+        NamespaceMissing = 103,
     }
 }

--- a/src/Thrift.Net.Compiler/Program.cs
+++ b/src/Thrift.Net.Compiler/Program.cs
@@ -140,6 +140,8 @@
                     => "An enum value must be specified",
                 CompilerMessageId.EnumMemberEqualsOperatorMissing
                     => "The `=` operator is missing between the enum member's name and value",
+                CompilerMessageId.EnumEmpty
+                    => "The enum has no members",
                 CompilerMessageId.NamespaceAndScopeMissing
                     => "A namespace and a namespace scope must be specified",
                 CompilerMessageId.NamespaceScopeMissing

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/EnumWarningTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/EnumWarningTests.cs
@@ -1,0 +1,24 @@
+namespace Thrift.Net.Tests.Compilation.ThriftCompiler
+{
+    using Thrift.Net.Compilation;
+    using Xunit;
+
+    public class EnumWarningTests : ThriftCompilerTests
+    {
+        [Fact]
+        public void Compile_EnumHasNoMembers_ReportsWarning()
+        {
+            this.AssertCompilerReturnsWarning(
+                "enum $UserType$ {}",
+                CompilerMessageId.EnumEmpty);
+        }
+
+        [Fact]
+        public void Compile_EnumWithMissingNameHasNoMembers_ReportsWarning()
+        {
+            this.AssertCompilerReturnsWarning(
+                "$enum$ {}",
+                CompilerMessageId.EnumEmpty);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ThriftCompilerTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ThriftCompilerTests.cs
@@ -10,6 +10,20 @@ namespace Thrift.Net.Tests.Compilation.ThriftCompiler
         protected void AssertCompilerReturnsError(
             string input, CompilerMessageId messageId)
         {
+            this.AssertCompilerReturnsMessage(
+                input, messageId, CompilerMessageType.Error);
+        }
+
+        protected void AssertCompilerReturnsWarning(
+            string input, CompilerMessageId messageId)
+        {
+            this.AssertCompilerReturnsMessage(
+                input, messageId, CompilerMessageType.Warning);
+        }
+
+        protected void AssertCompilerReturnsMessage(
+            string input, CompilerMessageId messageId, CompilerMessageType messageType)
+        {
             // Arrange
             var compiler = new ThriftCompiler();
             var parserInput = ParserInput.FromString(input);
@@ -18,13 +32,13 @@ namespace Thrift.Net.Tests.Compilation.ThriftCompiler
             var result = compiler.Compile(parserInput.GetStream());
 
             // Assert
-            var error = result.Errors.FirstOrDefault();
-            Assert.True(error != null, "No error messages were returned from the compiler");
-            Assert.Equal(messageId, error.MessageId);
-            Assert.Equal(CompilerMessageType.Error, error.MessageType);
-            Assert.Equal(parserInput.LineNumber, error.LineNumber);
-            Assert.Equal(parserInput.StartPosition, error.StartPosition);
-            Assert.Equal(parserInput.EndPosition, error.EndPosition);
+            var message = result.Messages.FirstOrDefault(m => m.MessageType == messageType);
+            Assert.True(message != null, $"No {messageType.ToString().ToLower()} messages were returned from the compiler");
+            Assert.Equal(messageId, message.MessageId);
+            Assert.Equal(messageType, message.MessageType);
+            Assert.Equal(parserInput.LineNumber, message.LineNumber);
+            Assert.Equal(parserInput.StartPosition, message.StartPosition);
+            Assert.Equal(parserInput.EndPosition, message.EndPosition);
         }
     }
 }

--- a/thrift-samples/enum.thrift
+++ b/thrift-samples/enum.thrift
@@ -16,3 +16,6 @@ enum Status {
     Success = 2,
     Failure
 }
+
+enum Empty {
+}


### PR DESCRIPTION
- Added a warning message to highlight if an enum has been defined with no members. The warning is
  displayed against the enum's name, or against the `enum` keyword if no name is specified.
- Updated the grammar to label the enum name, to make the code accessing it more understandable.
- Altered the message numbers in `CompilerMessageId` so that the messages for each piece of syntax
  (enum, namespace, struct, etc) have a group of 100 numbers. This gives us space to add new
  messages without having to constantly reorder the enum to keep related messages together.
- Updated compilation.md to indicate the type of each message.

Here's an example of the output:

```shell
Starting compilation of enum.thrift
Compilation succeeded with 1 warning(s):

thrift-samples/enum.thrift(38,6-10): Warning TC0006: The enum has no members [/home/adam/github.com/adamconnelly/thrift.net/thrift-samples/enum.thrift]
```