### PR TITLE
feat(compiler): improve invalid namespace scope

### DIFF
--- a/src/Thrift.Net.Compilation/CompilationMessage.cs
+++ b/src/Thrift.Net.Compilation/CompilationMessage.cs
@@ -84,16 +84,26 @@ namespace Thrift.Net.Compilation
         /// <param name="endToken">
         /// The end token that the error should be placed against.
         /// </param>
+        /// <param name="messageParameters">
+        /// Any parameters to include when formatting the compiler message.
+        /// </param>
         /// <returns>The error message.</returns>
-        public static CompilationMessage CreateError(CompilerMessageId messageId, IToken startToken, IToken endToken)
+        public static CompilationMessage CreateError(
+            CompilerMessageId messageId,
+            IToken startToken,
+            IToken endToken,
+            string[] messageParameters)
         {
+            string formattedMessage = string.Format(
+                CompilerMessages.Get(messageId), messageParameters);
+
             return new CompilationMessage(
                 messageId,
                 CompilerMessageType.Error,
                 startToken.Line,
                 startToken.Column + 1,
                 endToken.Column + endToken.Text.Length,
-                CompilerMessages.Get(messageId));
+                formattedMessage);
         }
 
         /// <summary>
@@ -106,16 +116,26 @@ namespace Thrift.Net.Compilation
         /// <param name="endToken">
         /// The end token that the warning should be placed against.
         /// </param>
+        /// <param name="messageParameters">
+        /// Any parameters to include when formatting the compiler message.
+        /// </param>
         /// <returns>The warning message.</returns>
-        public static CompilationMessage CreateWarning(CompilerMessageId messageId, IToken startToken, IToken endToken)
+        public static CompilationMessage CreateWarning(
+            CompilerMessageId messageId,
+            IToken startToken,
+            IToken endToken,
+            string[] messageParameters)
         {
+            string formattedMessage = string.Format(
+                CompilerMessages.Get(messageId), messageParameters);
+
             return new CompilationMessage(
                 messageId,
                 CompilerMessageType.Warning,
                 startToken.Line,
                 startToken.Column + 1,
                 endToken.Column + endToken.Text.Length,
-                CompilerMessages.Get(messageId));
+                formattedMessage);
         }
     }
 }

--- a/src/Thrift.Net.Compilation/CompilationVisitor.cs
+++ b/src/Thrift.Net.Compilation/CompilationVisitor.cs
@@ -177,7 +177,8 @@ namespace Thrift.Net.Compilation
                 // For example `namespace notalang mynamespace`
                 this.AddError(
                     CompilerMessageId.NamespaceScopeUnknown,
-                    context.namespaceScope);
+                    context.namespaceScope,
+                    context.namespaceScope.Text);
             }
         }
 
@@ -256,21 +257,21 @@ namespace Thrift.Net.Compilation
             return currentValue;
         }
 
-        private void AddError(CompilerMessageId messageId, IToken token)
+        private void AddError(CompilerMessageId messageId, IToken token, params string[] messageParameters)
         {
-            this.messages.Add(CompilationMessage.CreateError(messageId, token, token));
+            this.messages.Add(CompilationMessage.CreateError(messageId, token, token, messageParameters));
         }
 
-        private void AddError(CompilerMessageId messageId, IToken startToken, IToken endToken)
+        private void AddError(CompilerMessageId messageId, IToken startToken, IToken endToken, params string[] messageParameters)
         {
             this.messages.Add(CompilationMessage.CreateError(
-                messageId, startToken, endToken));
+                messageId, startToken, endToken, messageParameters));
         }
 
-        private void AddWarning(CompilerMessageId messageId, IToken token)
+        private void AddWarning(CompilerMessageId messageId, IToken token, params string[] messageParameters)
         {
             this.messages.Add(CompilationMessage.CreateWarning(
-                messageId, token, token));
+                messageId, token, token, messageParameters));
         }
     }
 }

--- a/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
+++ b/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
@@ -80,7 +80,7 @@
     <value>The enum has no members</value>
   </data>
   <data name="TC0100" xml:space="preserve">
-    <value>The specified namespace scope is not valid</value>
+    <value>'{0}' is not a valid namespace scope</value>
   </data>
   <data name="TC0101" xml:space="preserve">
     <value>A namespace scope must be specified</value>

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/NamespaceErrorTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/NamespaceErrorTests.cs
@@ -1,6 +1,8 @@
 namespace Thrift.Net.Tests.Compilation.ThriftCompiler
 {
+    using System.Linq;
     using Thrift.Net.Compilation;
+    using Thrift.Net.Compilation.Resources;
     using Thrift.Net.Tests.Extensions;
     using Xunit;
 
@@ -12,6 +14,22 @@ namespace Thrift.Net.Tests.Compilation.ThriftCompiler
             this.AssertCompilerReturnsError(
                 "namespace $notalang$ mynamespace",
                 CompilerMessageId.NamespaceScopeUnknown);
+        }
+
+        [Fact]
+        public void Compile_UnrecognisedNamespace_IncludesScopeInErrorMessage()
+        {
+            // Arrange
+            var input = "namespace notalang mynamespace";
+            var expectedMessage = string.Format(
+                CompilerMessages.Get(CompilerMessageId.NamespaceScopeUnknown), "notalang");
+            var compiler = new ThriftCompiler();
+
+            // Act
+            var result = compiler.Compile(input.ToStream());
+
+            // Assert
+            Assert.Equal(expectedMessage, result.Errors.First().Message);
         }
 
         [Theory]


### PR DESCRIPTION
I've updated the error message for an invalid namespace scope to include the invalid scope in the
error message.

The new error message looks like this:

```text
Error TC0100: 'notalang' is not a valid namespace scope
```