### PR TITLE
feat(compiler): error for duplicate enum

### DIFF
--- a/compilation.md
+++ b/compilation.md
@@ -276,6 +276,23 @@ enum UserType {
 }
 ```
 
+### TC0008 - Enum Duplicated
+
+_Level_: Error
+
+The same enum has been defined twice. For example:
+
+```thrift
+enum UserType {}
+enum UserType {}
+```
+
+To fix this issue rename or remove the duplicate. For example:
+
+```thrift
+enum UserType {}
+```
+
 ### TC0100 - Namespace Scope Unknown
 
 _Level_: Error

--- a/src/Thrift.Net.Compilation/CompilationVisitor.cs
+++ b/src/Thrift.Net.Compilation/CompilationVisitor.cs
@@ -49,7 +49,7 @@ namespace Thrift.Net.Compilation
                 "xsd",
             };
 
-        private readonly List<EnumDefinition> enums = new List<EnumDefinition>();
+        private readonly Dictionary<string, EnumDefinition> enums = new Dictionary<string, EnumDefinition>();
         private readonly List<CompilationMessage> messages = new List<CompilationMessage>();
         private readonly ParseTreeProperty<EnumMember> enumMembers = new ParseTreeProperty<EnumMember>();
 
@@ -65,7 +65,7 @@ namespace Thrift.Net.Compilation
         /// <summary>
         /// Gets the enums defined in the document.
         /// </summary>
-        public IReadOnlyCollection<EnumDefinition> Enums => this.enums;
+        public IReadOnlyCollection<EnumDefinition> Enums => this.enums.Values;
 
         /// <summary>
         /// Gets any messages reported during analysis.
@@ -124,8 +124,15 @@ namespace Thrift.Net.Compilation
 
             var name = this.GetEnumName(context);
             var members = this.GetEnumMembers(context);
+            var enumDefinition = new EnumDefinition(name, members.ToList());
 
-            this.enums.Add(new EnumDefinition(name, members.ToList()));
+            if (name != null && !this.enums.TryAdd(name, enumDefinition))
+            {
+                this.AddError(
+                    CompilerMessageId.EnumDuplicated,
+                    context.name,
+                    context.name.Text);
+            }
 
             if (!members.Any())
             {

--- a/src/Thrift.Net.Compilation/CompilerMessageId.cs
+++ b/src/Thrift.Net.Compilation/CompilerMessageId.cs
@@ -54,6 +54,16 @@ namespace Thrift.Net.Compilation
         EnumMemberDuplicated = 7,
 
         /// <summary>
+        /// An enum with the same name has been defined twice.
+        /// For example:
+        /// ```thrift
+        /// enum UserType {}
+        /// enum UserType {}
+        /// ```
+        /// </summary>
+        EnumDuplicated = 8,
+
+        /// <summary>
         /// The specified namespace scope is not in the list of known namespaces.
         /// For example `namespace notalang mynamespace`.
         /// </summary>

--- a/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
+++ b/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
@@ -82,6 +82,9 @@
   <data name="TC0007" xml:space="preserve">
     <value>Enum member '{0}' has already been defined</value>
   </data>
+  <data name="TC0008" xml:space="preserve">
+    <value>Enum '{0}' has already been defined</value>
+  </data>
   <data name="TC0100" xml:space="preserve">
     <value>'{0}' is not a valid namespace scope</value>
   </data>

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/EnumErrorTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/EnumErrorTests.cs
@@ -86,5 +86,32 @@ CompilerMessageId.EnumMemberDuplicated);
 CompilerMessageId.EnumMemberDuplicated,
 "User");
         }
+
+        [Fact]
+        public void Compile_EnumDuplicated_ReportsError()
+        {
+            this.AssertCompilerReturnsErrorId(
+@"enum UserType {
+    User
+}
+enum $UserType$ {
+    User
+}",
+CompilerMessageId.EnumDuplicated);
+        }
+
+        [Fact]
+        public void Compile_EnumDuplicated_ReportsErrorMessage()
+        {
+            this.AssertCompilerReturnsErrorMessage(
+@"enum UserType {
+    User
+}
+enum UserType {
+    User
+}",
+CompilerMessageId.EnumDuplicated,
+"UserType");
+        }
     }
 }


### PR DESCRIPTION
Added an error if an enum is defined twice. This is just a simple version of the check - once we've
got proper symbol resolution in place (#20) we'll want to also check for the situation where
the same enum is defined in separate files where the C# namespace is the same.

Issue: #9

Here's an example of the error message:

```text
thrift-samples/enum.thrift(20,6-16): Error TC0008: Enum 'Permissions' has already been defined [/home/adam/github.com/adamconnelly/thrift.net/thrift-samples/enum.thrift]
```