### PR TITLE
feat(compiler): implement basic struct parsing

### DIFF
--- a/binding.md
+++ b/binding.md
@@ -1,0 +1,76 @@
+# Binding
+
+Binding is the process of mapping between tokens in the syntax tree and Symbols.
+Symbols provide a richer view of the input code than we can get from the parse
+tree alone, and allow us to do things like detect duplicate identifiers, and
+match type names with their definitions.
+
+Binders use a tree structure to represent the scope rules in the Thrift IDL, so
+that we can detect duplicate identifiers, and also find symbols that were
+defined in a higher scope.
+
+```text
+Root
+  --> ThriftDocumentBinder
+    --> ImportBinder
+    --> NamespaceBinder
+    --> EnumBinder
+      --> EnumMemberBinder
+    --> StructBinder
+      --> FieldBinder
+    --> ExceptionBinder
+      --> FieldBinder
+    --> ServiceBinder
+      --> ParameterListBinder
+```
+
+When we perform further analysis of the code to report errors and warnings, we
+can use the Binder for the current scope to get semantic information about the
+code, for example the value of the current enum member, or whether it has been
+declared multiple times.
+
+## Symbols
+
+Symbols represent the different types of Thrift object, like structs, enums and
+fields. Each symbol is represented by a class implementing `ISymbol`.
+
+## Binders
+
+Each Symbol has an associated Binder, that knows how to create the Symbol based
+on a node in the parse tree.
+
+## Binder Provider
+
+The `BinderProvider` is used to map between a node in the parse tree and the
+Binder used to bind it to a Symbol. The BinderProvider uses a visitor to visit
+nodes in the parse tree and associate them with the correct Binder.
+
+## Type Resolution
+
+Binders support resolving types using the `ResolveType()` method. This returns a
+`FieldType` object containing information about the type. Because Binders are
+built in a tree structure to represent the scope, type resolution can walk up
+this tree until it finds a binder that can resolve the specified type.
+
+For example, if we have the following Thrift definition:
+
+```thrift
+enum UserType {
+  User
+  Administrator
+}
+
+struct User {
+  1: $UserType$ Type
+}
+```
+
+If we try to resolve the `UserType` token surrounded by the `$` signs,
+resolution will take the following path:
+
+```text
+FieldTypeBinder
+  --> FieldBinder
+    --> StructBinder
+      --> DocumentBinder
+```

--- a/compilation.md
+++ b/compilation.md
@@ -1,7 +1,17 @@
 # Compilation
 
+- [Compilation Overview](#compilation-overview).
 - [Explanation of the message format](#message-format).
 - [Full list of messages](#messages).
+
+## Compilation Overview
+
+Compilation is made up of a number of stages:
+
+- Parsing the input text into a syntax tree.
+- [Binding](binding.md) the nodes in the tree into Symbols.
+- Performing analysis and reporting any errors or warnings.
+- Code generation.
 
 ## Message Format
 

--- a/src/Thrift.Net.Antlr/Thrift.g4
+++ b/src/Thrift.Net.Antlr/Thrift.g4
@@ -10,7 +10,7 @@ namespaceStatement: NAMESPACE (namespaceScope=.*? | namespaceScope='*') ns=IDENT
 
 definitions: definition*;
 
-definition: enumDefinition;
+definition: enumDefinition | structDefinition;
 
 enumDefinition: ENUM name=IDENTIFIER?
     '{'
@@ -23,8 +23,23 @@ enumMember: (
         IDENTIFIER enumValue=.*?                      // `User 123` (missing =)
     ) LIST_SEPARATOR?;
 
+structDefinition: STRUCT name=IDENTIFIER?
+    '{'
+        field*
+    '}';
+
+field: fieldType name=IDENTIFIER |
+    fieldRequiredness fieldType name=IDENTIFIER |
+    fieldId=.+? ':' fieldRequiredness? fieldType name=IDENTIFIER;
+
+fieldRequiredness: REQUIRED | OPTIONAL;
+fieldType: IDENTIFIER;
+
 NAMESPACE: 'namespace';
 ENUM: 'enum';
+STRUCT: 'struct';
+REQUIRED: 'required';
+OPTIONAL: 'optional';
 EQUALS_OPERATOR: '=';
 LITERAL: ( '"' .*? '"' ) | ( '\'' .*? '\'' );
 IDENTIFIER: ( [a-zA-Z] | '_' ) ( [a-zA-Z] | [0-9] | '.' | '_' )*;

--- a/src/Thrift.Net.Compilation/Binding/Binder.cs
+++ b/src/Thrift.Net.Compilation/Binding/Binder.cs
@@ -1,0 +1,58 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using System;
+    using Antlr4.Runtime;
+    using Thrift.Net.Compilation.Model;
+
+    /// <summary>
+    /// A base class for binders.
+    /// </summary>
+    /// <typeparam name="TNode">The type of node this binder can bind.</typeparam>
+    /// <typeparam name="TResult">The type of symbol produced by the binder.</typeparam>
+    public abstract class Binder<TNode, TResult> : IBinder
+        where TNode : ParserRuleContext
+        where TResult : ISymbol
+    {
+        private readonly IBinder parent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Binder{TNode, TResult}" /> class.
+        /// </summary>
+        /// <param name="parent">The parent binder.</param>
+        protected Binder(IBinder parent)
+        {
+            this.parent = parent;
+        }
+
+        /// <inheritdoc />
+        public virtual FieldType ResolveType(string typeName)
+        {
+            return this.parent.ResolveType(typeName);
+        }
+
+        /// <inheritdoc />
+        public TSymbol Bind<TSymbol>(ParserRuleContext node)
+            where TSymbol : class, ISymbol
+        {
+            if (!(node is TNode))
+            {
+                throw new InvalidOperationException($"This binder can only bind {typeof(TNode).Name} nodes");
+            }
+
+            var boundSymbol = this.Bind(node as TNode);
+            if (!(boundSymbol is TSymbol result))
+            {
+                throw new InvalidOperationException($"This binder can only be used to bind {typeof(TResult).Name} objects");
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Binds the specified node, returning its symbol.
+        /// </summary>
+        /// <param name="node">The node to bind.</param>
+        /// <returns>The bound symbol.</returns>
+        protected abstract TResult Bind(TNode node);
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/BinderProvider.cs
+++ b/src/Thrift.Net.Compilation/Binding/BinderProvider.cs
@@ -1,0 +1,94 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using Antlr4.Runtime;
+    using Antlr4.Runtime.Misc;
+    using Antlr4.Runtime.Tree;
+    using Thrift.Net.Antlr;
+    using Thrift.Net.Compilation.Model;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// The BinderProvider is used to get <see cref="IBinder" /> objects that
+    /// can be used to create <see cref="ISymbol" /> objects from the parse tree.
+    /// </summary>
+    public class BinderProvider : IBinderProvider
+    {
+        private readonly ParseTreeProperty<IBinder> binderMap = new ParseTreeProperty<IBinder>();
+        private readonly BinderVisitor binderVisitor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinderProvider" /> class.
+        /// </summary>
+        public BinderProvider()
+        {
+            this.binderVisitor = new BinderVisitor(this, this.binderMap);
+        }
+
+        /// <summary>
+        /// Adds the nodes in the document to the set that binders can be
+        /// provided for.
+        /// </summary>
+        /// <param name="documentContext">The document.</param>
+        public void AddDocument(DocumentContext documentContext)
+        {
+            documentContext.Accept(this.binderVisitor);
+        }
+
+        /// <summary>
+        /// Gets the binder for the specified node.
+        /// </summary>
+        /// <param name="node">The node to get the binder for.</param>
+        /// <returns>
+        /// The binder, or null if no binder exists for the specified node.
+        /// </returns>
+        public IBinder GetBinder(ParserRuleContext node)
+        {
+            return this.binderMap.Get(node);
+        }
+
+        private class BinderVisitor : ThriftBaseVisitor<IBinder>
+        {
+            private readonly ParseTreeProperty<IBinder> binderMap;
+            private readonly IBinderProvider binderProvider;
+
+            public BinderVisitor(
+                IBinderProvider binderProvider, ParseTreeProperty<IBinder> binderMap)
+            {
+                this.binderProvider = binderProvider;
+                this.binderMap = binderMap;
+            }
+
+            public override IBinder VisitField([NotNull] ThriftParser.FieldContext context)
+            {
+                var containerBinder = this.binderMap.Get(context.Parent) as IFieldContainerBinder;
+                var binder = new FieldBinder(containerBinder, this.binderProvider);
+                this.binderMap.Put(context, binder);
+
+                base.VisitField(context);
+
+                return binder;
+            }
+
+            public override IBinder VisitFieldType([NotNull] FieldTypeContext context)
+            {
+                base.VisitFieldType(context);
+
+                var binder = new FieldTypeBinder(this.binderMap.Get(context.Parent));
+                this.binderMap.Put(context, binder);
+
+                return binder;
+            }
+
+            public override IBinder VisitStructDefinition([NotNull] StructDefinitionContext context)
+            {
+                // TODO: Pass in document binder
+                var structBinder = new StructBinder(null, this.binderProvider);
+                this.binderMap.Put(context, structBinder);
+
+                base.VisitStructDefinition(context);
+
+                return structBinder;
+            }
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/FieldBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/FieldBinder.cs
@@ -1,0 +1,79 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using Thrift.Net.Compilation.Model;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Used to bind fields based on a parse tree.
+    /// </summary>
+    public class FieldBinder : Binder<FieldContext, FieldDefinition>, IBinder
+    {
+        private readonly IFieldContainerBinder containerBinder;
+        private readonly IBinderProvider binderProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldBinder" /> class.
+        /// </summary>
+        /// <param name="containerBinder">The container binder.</param>
+        /// <param name="binderProvider">Used to find binders for child nodes.</param>
+        public FieldBinder(
+            IFieldContainerBinder containerBinder, IBinderProvider binderProvider)
+            : base(containerBinder)
+        {
+            this.containerBinder = containerBinder;
+            this.binderProvider = binderProvider;
+        }
+
+        /// <summary>
+        /// Binds the specified field.
+        /// </summary>
+        /// <param name="context">The parsed field.</param>
+        /// <returns>The field definition.</returns>
+        protected override FieldDefinition Bind(FieldContext context)
+        {
+            var fieldId = this.GetFieldId(context);
+            var requiredness = this.GetFieldRequiredness(context);
+            var typeBinder = this.binderProvider.GetBinder(context.fieldType());
+            var type = typeBinder.Bind<FieldType>(context.fieldType());
+
+            return new FieldDefinition(
+                fieldId, context.fieldId?.Text, requiredness, type, context.name.Text);
+        }
+
+        private FieldRequiredness GetFieldRequiredness(FieldContext context)
+        {
+            if (context.fieldRequiredness()?.REQUIRED() != null)
+            {
+                return FieldRequiredness.Required;
+            }
+
+            if (context.fieldRequiredness()?.OPTIONAL() != null)
+            {
+                return FieldRequiredness.Optional;
+            }
+
+            return this.containerBinder.DefaultFieldRequiredness;
+        }
+
+        private int? GetFieldId(FieldContext context)
+        {
+            if (context.fieldId != null)
+            {
+                if (int.TryParse(context.fieldId.Text, out var fieldId))
+                {
+                    return fieldId;
+                }
+
+                return null;
+            }
+
+            var previousField = this.containerBinder.GetPreviousSibling(context);
+            if (previousField != null)
+            {
+                return previousField.FieldId + 1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/FieldTypeBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/FieldTypeBinder.cs
@@ -1,0 +1,55 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using Thrift.Net.Compilation.Model;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Used to bind the type of fields.
+    /// </summary>
+    public class FieldTypeBinder : Binder<FieldTypeContext, FieldType>, IBinder
+    {
+        private readonly IBinder parent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldTypeBinder" /> class.
+        /// </summary>
+        /// <param name="parent">The parent binder.</param>
+        public FieldTypeBinder(IBinder parent)
+            : base(parent)
+        {
+            this.parent = parent;
+        }
+
+        /// <inheritdoc />
+        public override FieldType ResolveType(string typeName)
+        {
+            return this.parent.ResolveType(typeName);
+        }
+
+        /// <summary>
+        /// Uses the parsed field type to create a <see cref="FieldType" /> object.
+        /// </summary>
+        /// <param name="context">The parsed type name.</param>
+        /// <returns>The field type, or null if the type could not be resolved.</returns>
+        protected override FieldType Bind(FieldTypeContext context)
+        {
+            var typeName = context.IDENTIFIER().Symbol.Text;
+            var baseType = FieldType.ResolveBaseType(typeName);
+            if (baseType != null)
+            {
+                return baseType;
+            }
+
+            if (typeName.Split('.').Length <= 2)
+            {
+                var userType = this.parent.ResolveType(typeName);
+                if (userType != null)
+                {
+                    return userType;
+                }
+            }
+
+            return FieldType.CreateUnresolvedType(typeName);
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/IBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/IBinder.cs
@@ -1,0 +1,33 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using System;
+    using Antlr4.Runtime;
+    using Thrift.Net.Compilation.Model;
+
+    /// <summary>
+    /// An object that can bind a node in the parse tree to its semantic
+    /// representation.
+    /// </summary>
+    public interface IBinder
+    {
+        /// <summary>
+        /// Resolves the specified type.
+        /// </summary>
+        /// <param name="typeName">The name of the type to resolve.</param>
+        /// <returns>The type, or null if the type could not be resolved.</returns>
+        FieldType ResolveType(string typeName);
+
+        /// <summary>
+        /// Creates a symbol based on the specified node.
+        /// </summary>
+        /// <param name="node">The node in the tree to get the symbol for.</param>
+        /// <typeparam name="TSymbol">The type of the symbol.</typeparam>
+        /// <returns>The symbol.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the symbol created from the node cannot be converted to
+        /// <typeparamref name="TSymbol" />.
+        /// </exception>
+        TSymbol Bind<TSymbol>(ParserRuleContext node)
+            where TSymbol : class, ISymbol;
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/IBinderProvider.cs
+++ b/src/Thrift.Net.Compilation/Binding/IBinderProvider.cs
@@ -1,0 +1,18 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using Antlr4.Runtime;
+
+    /// <summary>
+    /// An object that can provide the correct <see cref="IBinder" /> for nodes
+    /// in the parse tree.
+    /// </summary>
+    public interface IBinderProvider
+    {
+        /// <summary>
+        /// Gets the binder for the specified node.
+        /// </summary>
+        /// <param name="node">The node in the tree to get the binder for.</param>
+        /// <returns>The binder for the specified node.</returns>
+        IBinder GetBinder(ParserRuleContext node);
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/IFieldContainerBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/IFieldContainerBinder.cs
@@ -1,0 +1,27 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using Thrift.Net.Compilation.Model;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// A Binder that binds elements containing fields.
+    /// </summary>
+    public interface IFieldContainerBinder : IBinder
+    {
+        /// <summary>
+        /// Gets the default requiredness for this type of container.
+        /// </summary>
+        /// <remarks>
+        /// This is required because unions have a different default requireness
+        /// than structs or exceptions.
+        /// </remarks>
+        FieldRequiredness DefaultFieldRequiredness { get; }
+
+        /// <summary>
+        /// Gets the field defined immediately before the specified field.
+        /// </summary>
+        /// <param name="context">The field to look before.</param>
+        /// <returns>The previous field, or null if there is no previous field.</returns>
+        FieldDefinition GetPreviousSibling(FieldContext context);
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/StructBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/StructBinder.cs
@@ -1,0 +1,74 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using System.Linq;
+    using Thrift.Net.Compilation.Model;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Used to bind a <see cref="StructDefinition" /> from the parse tree.
+    /// </summary>
+    public class StructBinder : Binder<StructDefinitionContext, StructDefinition>, IBinder, IFieldContainerBinder
+    {
+        private readonly IBinderProvider binderProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StructBinder" /> class.
+        /// </summary>
+        /// <param name="parent">The parent binder.</param>
+        /// <param name="binderProvider">
+        /// Used to get the correct binder for a particular node.
+        /// </param>
+        public StructBinder(IBinder parent, IBinderProvider binderProvider)
+            : base(parent)
+        {
+            this.binderProvider = binderProvider;
+        }
+
+        /// <inheritdoc />
+        public FieldRequiredness DefaultFieldRequiredness => FieldRequiredness.Default;
+
+        /// <inheritdoc />
+        public FieldDefinition GetPreviousSibling(FieldContext target)
+        {
+            var parentNode = target.Parent as StructDefinitionContext;
+            FieldContext previousFieldNode = null;
+
+            foreach (var fieldNode in parentNode.field())
+            {
+                if (fieldNode == target)
+                {
+                    break;
+                }
+
+                previousFieldNode = fieldNode;
+            }
+
+            if (previousFieldNode != null)
+            {
+                var binder = this.binderProvider.GetBinder(previousFieldNode);
+                return binder.Bind<FieldDefinition>(previousFieldNode);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="StructDefinition" /> based on the parse tree node.
+        /// </summary>
+        /// <param name="context">The node to bind.</param>
+        /// <returns>The struct definition.</returns>
+        protected override StructDefinition Bind(StructDefinitionContext context)
+        {
+            var fields = context.field().Select(this.GetField);
+
+            return new StructDefinition(context.name?.Text, fields.ToList());
+        }
+
+        private FieldDefinition GetField(FieldContext context)
+        {
+            var binder = this.binderProvider.GetBinder(context);
+
+            return binder.Bind<FieldDefinition>(context);
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Model/FieldDefinition.cs
+++ b/src/Thrift.Net.Compilation/Model/FieldDefinition.cs
@@ -1,0 +1,62 @@
+namespace Thrift.Net.Compilation.Model
+{
+    /// <summary>
+    /// Represents a field in a struct, union or exception.
+    /// </summary>
+    public class FieldDefinition : ISymbol
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldDefinition" /> class.
+        /// </summary>
+        /// <param name="fieldId">The field's Id.</param>
+        /// <param name="rawFieldId">The raw text representing the field Id.</param>
+        /// <param name="requiredness">The level of requiredness of the field.</param>
+        /// <param name="type">The type of the field.</param>
+        /// <param name="name">The name of the field.</param>
+        public FieldDefinition(
+            int? fieldId,
+            string rawFieldId,
+            FieldRequiredness requiredness,
+            FieldType type,
+            string name)
+        {
+            this.FieldId = fieldId;
+            this.RawFieldId = rawFieldId;
+            this.Requiredness = requiredness;
+            this.Type = type;
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Gets the field's name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the Id of the field.
+        /// </summary>
+        public int? FieldId { get; }
+
+        /// <summary>
+        /// Gets the raw text of the field Id rather than the integer value
+        /// stored in <see cref="FieldId" />.
+        /// </summary>
+        public string RawFieldId { get; }
+
+        /// <summary>
+        /// Gets the level of requiredness of this field.
+        /// </summary>
+        public FieldRequiredness Requiredness { get; }
+
+        /// <summary>
+        /// Gets the data type of the field.
+        /// </summary>
+        public FieldType Type { get; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{this.FieldId}: {this.Requiredness} {this.Type} {this.Name}";
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Model/FieldRequiredness.cs
+++ b/src/Thrift.Net.Compilation/Model/FieldRequiredness.cs
@@ -1,0 +1,42 @@
+namespace Thrift.Net.Compilation.Model
+{
+    /// <summary>
+    /// Defines whether or not a field is required.
+    /// </summary>
+    public enum FieldRequiredness
+    {
+        /// <summary>
+        /// The default (implicit) level of requiredness if none is explicitly
+        /// specified.
+        /// </summary>
+        /// <remarks>
+        /// - Write: In theory, the fields are always written, however there are
+        ///   some exceptions to this rule, including when the default value of
+        ///   the field cannot be serialized by Thrift.
+        /// - Read: Like optional, the field may, or may not be part of the input stream.
+        /// - Default values: may or may not be written.
+        /// </remarks>
+        Default,
+
+        /// <summary>
+        /// The field is required.
+        /// </summary>
+        /// <remarks>
+        /// - Write: Required fields are always written and are expected to be set.
+        /// - Read: Required fields are always read and are expected to be contained
+        ///   in the input stream.
+        /// - Default values: are always written.
+        /// </remarks>
+        Required,
+
+        /// <summary>
+        /// The field is optional.
+        /// </summary>
+        /// <remarks>
+        /// - Write: Optional fields are only written when they are set.
+        /// - Read: Optional fields may, or may not be part of the input stream.
+        /// - Default values: are written when the isset flag is set.
+        /// </remarks>
+        Optional,
+    }
+}

--- a/src/Thrift.Net.Compilation/Model/FieldType.cs
+++ b/src/Thrift.Net.Compilation/Model/FieldType.cs
@@ -1,0 +1,166 @@
+namespace Thrift.Net.Compilation.Model
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents the type of a field.
+    /// </summary>
+    public class FieldType : ISymbol
+    {
+        /// <summary>
+        /// The 'bool' base type.
+        /// </summary>
+        public static readonly FieldType Bool = CreateResolvedType("bool");
+
+        /// <summary>
+        /// The 'byte' base type.
+        /// </summary>
+        public static readonly FieldType Byte = CreateResolvedType("byte");
+
+        /// <summary>
+        /// The 'i8' base type.
+        /// </summary>
+        public static readonly FieldType I8 = CreateResolvedType("i8");
+
+        /// <summary>
+        /// The 'i16' base type.
+        /// </summary>
+        public static readonly FieldType I16 = CreateResolvedType("i16");
+
+        /// <summary>
+        /// The 'i32' base type.
+        /// </summary>
+        public static readonly FieldType I32 = CreateResolvedType("i32");
+
+        /// <summary>
+        /// The 'i64' base type.
+        /// </summary>
+        public static readonly FieldType I64 = CreateResolvedType("i64");
+
+        /// <summary>
+        /// The 'double' base type.
+        /// </summary>
+        public static readonly FieldType Double = CreateResolvedType("double");
+
+        /// <summary>
+        /// The 'string' base type.
+        /// </summary>
+        public static readonly FieldType String = CreateResolvedType("string");
+
+        /// <summary>
+        /// The 'binary' base type.
+        /// </summary>
+        public static readonly FieldType Binary = CreateResolvedType("binary");
+
+        /// <summary>
+        /// The 'slist' base type.
+        /// </summary>
+        public static readonly FieldType SList = FieldType.CreateResolvedType("slist");
+
+        private static readonly Dictionary<string, FieldType> BaseTypeMap =
+            new Dictionary<string, FieldType>
+            {
+                { Bool.Name, Bool },
+                { Byte.Name, Byte },
+                { I8.Name, I8 },
+                { I16.Name, I16 },
+                { I32.Name, I32 },
+                { I64.Name, I64 },
+                { Double.Name, Double },
+                { String.Name, String },
+                { Binary.Name, Binary },
+                { SList.Name, SList },
+            };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldType" /> class.
+        /// </summary>
+        /// <param name="name">The name of the type.</param>
+        /// <param name="identifierPartsCount">
+        /// The number of parts that make up the type name.
+        /// </param>
+        /// <param name="isResolved">
+        /// Indicates whether the type has been resolved successfully or not.
+        /// </param>
+        public FieldType(string name, int identifierPartsCount, bool isResolved)
+        {
+            this.Name = name;
+            this.IdentifierPartsCount = identifierPartsCount;
+            this.IsResolved = isResolved;
+        }
+
+        /// <summary>
+        /// Gets the list of base (built-in) types.
+        /// </summary>
+        public static IReadOnlyCollection<FieldType> BaseTypes => BaseTypeMap.Values;
+
+        /// <summary>
+        /// Gets the name of the type.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the type has successfully been
+        /// resolved. If this is false it means the type could not be found.
+        /// </summary>
+        public bool IsResolved { get; }
+
+        /// <summary>
+        /// Gets the number of parts that make up the type name. This will be
+        /// 1 for a simple type like `i32`, and 2 for a multi-part identifier
+        /// like `Enums.UserType`.
+        /// </summary>
+        public int IdentifierPartsCount { get; }
+
+        /// <summary>
+        /// Creates a new type marked as resolved.
+        /// </summary>
+        /// <param name="typeName">The name of the type.</param>
+        /// <returns>
+        /// The type.
+        /// </returns>
+        public static FieldType CreateResolvedType(string typeName)
+        {
+            var nameParts = typeName.Split('.');
+
+            return new FieldType(typeName, nameParts.Length, true);
+        }
+
+        /// <summary>
+        /// Creates a new type marked as unresolved.
+        /// </summary>
+        /// <param name="typeName">The name of the type.</param>
+        /// <returns>
+        /// The type.
+        /// </returns>
+        public static FieldType CreateUnresolvedType(string typeName)
+        {
+            var nameParts = typeName.Split('.');
+
+            return new FieldType(typeName, nameParts.Length, false);
+        }
+
+        /// <summary>
+        /// Gets the base type with the specified name.
+        /// </summary>
+        /// <param name="typeName">The name of the type.</param>
+        /// <returns>
+        /// The base type, or null if the specified name isn't a base type.
+        /// </returns>
+        public static FieldType ResolveBaseType(string typeName)
+        {
+            if (BaseTypeMap.TryGetValue(typeName, out var fieldType))
+            {
+                return fieldType;
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return this.Name;
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Model/ISymbol.cs
+++ b/src/Thrift.Net.Compilation/Model/ISymbol.cs
@@ -1,0 +1,9 @@
+namespace Thrift.Net.Compilation.Model
+{
+    /// <summary>
+    /// Represents a symbol in the semantic model.
+    /// </summary>
+    public interface ISymbol
+    {
+    }
+}

--- a/src/Thrift.Net.Compilation/Model/StructDefinition.cs
+++ b/src/Thrift.Net.Compilation/Model/StructDefinition.cs
@@ -1,0 +1,37 @@
+namespace Thrift.Net.Compilation.Model
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents a Thrift struct.
+    /// </summary>
+    public class StructDefinition : ISymbol
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StructDefinition" /> class.
+        /// </summary>
+        /// <param name="name">The name of the struct.</param>
+        /// <param name="fields">The struct's fields.</param>
+        public StructDefinition(string name, IReadOnlyCollection<FieldDefinition> fields)
+        {
+            this.Name = name;
+            this.Fields = fields;
+        }
+
+        /// <summary>
+        /// Gets the name of the struct.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the fields of the struct.
+        /// </summary>
+        public IReadOnlyCollection<FieldDefinition> Fields { get; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"struct {this.Name}";
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Model/ThriftDocument.cs
+++ b/src/Thrift.Net.Compilation/Model/ThriftDocument.cs
@@ -12,10 +12,15 @@ namespace Thrift.Net.Compilation.Model
         /// </summary>
         /// <param name="namespace">The C# namespace of the document.</param>
         /// <param name="enums">Any enums found in the document.</param>
-        public ThriftDocument(string @namespace, IReadOnlyCollection<EnumDefinition> enums)
+        /// <param name="structs">Any structs found in the document.</param>
+        public ThriftDocument(
+            string @namespace,
+            IReadOnlyCollection<EnumDefinition> enums,
+            IReadOnlyCollection<StructDefinition> structs)
         {
             this.Namespace = @namespace;
             this.Enums = enums;
+            this.Structs = structs;
         }
 
         /// <summary>
@@ -27,5 +32,10 @@ namespace Thrift.Net.Compilation.Model
         /// Gets any enums that have been defined.
         /// </summary>
         public IReadOnlyCollection<EnumDefinition> Enums { get; }
+
+        /// <summary>
+        /// Gets any structs that have been defined.
+        /// </summary>
+        public IReadOnlyCollection<StructDefinition> Structs { get; }
     }
 }

--- a/src/Thrift.Net.Compilation/ThriftParserFactory.cs
+++ b/src/Thrift.Net.Compilation/ThriftParserFactory.cs
@@ -1,0 +1,26 @@
+namespace Thrift.Net.Compilation
+{
+    using System.IO;
+    using Antlr4.Runtime;
+    using Thrift.Net.Antlr;
+
+    /// <summary>
+    /// Used to create <see cref="ThriftParser" /> instances.
+    /// </summary>
+    public static class ThriftParserFactory
+    {
+        /// <summary>
+        /// Creates a new parser from the specified input stream.
+        /// </summary>
+        /// <param name="inputStream">The stream to parse.</param>
+        /// <returns>The parser.</returns>
+        public static ThriftParser Create(Stream inputStream)
+        {
+            var charStream = new AntlrInputStream(inputStream);
+            var lexer = new ThriftLexer(charStream);
+            var tokenStream = new CommonTokenStream(lexer);
+
+            return new ThriftParser(tokenStream);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/FieldIdTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/FieldIdTests.cs
@@ -1,0 +1,123 @@
+namespace Thrift.Net.Tests.Compilation.Binding.FieldBinder
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Model;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class FieldIdTests
+    {
+        private readonly IFieldContainerBinder containerBinder = Substitute.For<IFieldContainerBinder>();
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+        private readonly FieldBinder binder;
+
+        public FieldIdTests()
+        {
+            this.binder = new FieldBinder(this.containerBinder, this.binderProvider);
+        }
+
+        [Fact]
+        public void Bind_FieldIdProvided_SetsFieldId()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("1: i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal(1, field.FieldId);
+        }
+
+        [Fact]
+        public void Bind_FieldIdNotProvided_DefaultsIdToZero()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal(0, field.FieldId);
+        }
+
+        [Fact]
+        public void Bind_FieldIdNotProvided_UsesSiblingToSetId()
+        {
+            // Arrange
+            var previousField = CreateFieldWithId(5);
+
+            var fieldContext = ParserInput
+                .FromString("i32 Id")
+                .ParseInput(parser => parser.field());
+            this.containerBinder.GetPreviousSibling(fieldContext).Returns(previousField);
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal(6, field.FieldId);
+        }
+
+        [Fact]
+        public void Bind_FieldIdNegative_SetsFieldId()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("-1: i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal(-1, field.FieldId);
+        }
+
+        [Fact]
+        public void Bind_FieldIdSupplied_SetsRawFieldId()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("4: i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal("4", field.RawFieldId);
+        }
+
+        [Fact]
+        public void Bind_FieldIdNotAnInteger_SetsFieldIdNull()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("abc: i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Null(field.FieldId);
+        }
+
+        private static FieldDefinition CreateFieldWithId(int fieldId)
+        {
+            return new FieldDefinition(
+                fieldId,
+                fieldId.ToString(),
+                FieldRequiredness.Default,
+                FieldType.Bool,
+                "IsEnabled");
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/FieldTypeTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/FieldTypeTests.cs
@@ -1,0 +1,41 @@
+namespace Thrift.Net.Tests.Compilation.Binding.FieldBinder
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Model;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class FieldTypeTests
+    {
+        private readonly IFieldContainerBinder containerBinder = Substitute.For<IFieldContainerBinder>();
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+        private readonly IBinder typeBinder = Substitute.For<IBinder>();
+        private readonly FieldBinder binder;
+
+        public FieldTypeTests()
+        {
+            this.binder = new FieldBinder(this.containerBinder, this.binderProvider);
+        }
+
+        [Fact]
+        public void Bind_FieldTypeSupplied_UsesBinderToResolveType()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("i32 Id")
+                .ParseInput(parser => parser.field());
+
+            this.binderProvider.GetBinder(fieldContext.fieldType())
+                .Returns(this.typeBinder);
+            this.typeBinder.Bind<FieldType>(fieldContext.fieldType())
+                .Returns(FieldType.Bool);
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Same(FieldType.Bool, field.Type);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/IdentifierTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/IdentifierTests.cs
@@ -1,0 +1,35 @@
+namespace Thrift.Net.Tests.Compilation.Binding.FieldBinder
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Model;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class IdentifierTests
+    {
+        private readonly IFieldContainerBinder containerBinder = Substitute.For<IFieldContainerBinder>();
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+        private readonly FieldBinder binder;
+
+        public IdentifierTests()
+        {
+            this.binder = new FieldBinder(this.containerBinder, this.binderProvider);
+        }
+
+        [Fact]
+        public void Bind_IdentifierSupplied_SetsIdentifier()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("string Name")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal("Name", field.Name);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/RequirednessTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/RequirednessTests.cs
@@ -1,0 +1,68 @@
+namespace Thrift.Net.Tests.Compilation.Binding.FieldBinder
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Model;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class RequirednessTests
+    {
+        private readonly IFieldContainerBinder containerBinder = Substitute.For<IFieldContainerBinder>();
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+        private readonly FieldBinder binder;
+
+        public RequirednessTests()
+        {
+            this.binder = new FieldBinder(this.containerBinder, this.binderProvider);
+        }
+
+        [Fact]
+        public void Bind_FieldRequirednessNotSupplied_UsesDefault()
+        {
+            // Arrange
+            this.containerBinder.DefaultFieldRequiredness
+                .Returns(FieldRequiredness.Optional);
+
+            var fieldContext = ParserInput
+                .FromString("i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal(FieldRequiredness.Optional, field.Requiredness);
+        }
+
+        [Fact]
+        public void Bind_FieldRequirednessRequired_SetsRequiredness()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("required i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal(FieldRequiredness.Required, field.Requiredness);
+        }
+
+        [Fact]
+        public void Bind_FieldRequirednessOptional_SetsRequiredness()
+        {
+            // Arrange
+            var fieldContext = ParserInput
+                .FromString("optional i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<FieldDefinition>(fieldContext);
+
+            // Assert
+            Assert.Equal(FieldRequiredness.Optional, field.Requiredness);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/FieldTypeBinder/FieldTypeBinderTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/FieldTypeBinder/FieldTypeBinderTests.cs
@@ -1,0 +1,115 @@
+namespace Thrift.Net.Tests.Compilation.Binding.FieldBinder
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Model;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class FieldTypeBinderTests
+    {
+        private readonly IBinder parentBinder = Substitute.For<IBinder>();
+        private readonly FieldTypeBinder binder;
+
+        public FieldTypeBinderTests()
+        {
+            this.binder = new FieldTypeBinder(this.parentBinder);
+        }
+
+        public static IEnumerable<object[]> GetBaseTypes()
+        {
+            return FieldType.BaseTypes.Select(type => new object[] { type });
+        }
+
+        [Theory]
+        [MemberData(nameof(GetBaseTypes))]
+        public void Bind_BaseType_ResolvesType(FieldType expectedType)
+        {
+            // Arrange
+            var fieldTypeContext = ParserInput
+                .FromString(expectedType.Name)
+                .ParseInput(parser => parser.fieldType());
+
+            // Act
+            var type = this.binder.Bind<FieldType>(fieldTypeContext);
+
+            // Assert
+            Assert.Same(expectedType, type);
+        }
+
+        [Fact]
+        public void Bind_NotBaseType_ResolvesTypeUsingParent()
+        {
+            // Arrange
+            var input = "UserType";
+            var fieldTypeContext = ParserInput
+                .FromString(input)
+                .ParseInput(parser => parser.fieldType());
+
+            var resolvedType = FieldType.CreateResolvedType(input);
+            this.parentBinder.ResolveType(input).Returns(resolvedType);
+
+            // Act
+            var type = this.binder.Bind<FieldType>(fieldTypeContext);
+
+            // Assert
+            Assert.Same(resolvedType, type);
+        }
+
+        [Fact]
+        public void Bind_TypeCannotResolve_ReturnsUnresolvedType()
+        {
+            // Arrange
+            var input = "NonExistentType";
+            var fieldTypeContext = ParserInput
+                .FromString(input)
+                .ParseInput(parser => parser.fieldType());
+
+            // Act
+            var type = this.binder.Bind<FieldType>(fieldTypeContext);
+
+            // Assert
+            Assert.False(type.IsResolved);
+        }
+
+        [Theory]
+        [InlineData("i32", 1)]
+        [InlineData("Enums.UserType", 2)]
+        [InlineData("One.Two.Three", 3)]
+        public void Bind_MultiPartIdentifier_SetsIdentifierPartCount(
+            string identifier, int parts)
+        {
+            // Arrange
+            var fieldTypeContext = ParserInput
+                .FromString(identifier)
+                .ParseInput(parser => parser.fieldType());
+
+            // Act
+            var type = this.binder.Bind<FieldType>(fieldTypeContext);
+
+            // Assert
+            Assert.Equal(parts, type.IdentifierPartsCount);
+        }
+
+        [Fact]
+        public void Bind_MultiPartIdentifierWithMoreThanTwoParts_DoesNotResolveTypeUsingParent()
+        {
+            // Thrift only support simple names, or names with a single prefix,
+            // so don't bother trying to resolve a type if it has more than two
+            // parts.
+            //
+            // Arrange
+            var fieldTypeContext = ParserInput
+                .FromString("One.Two.Three")
+                .ParseInput(parser => parser.fieldType());
+
+            // Act
+            this.binder.Bind<FieldType>(fieldTypeContext);
+
+            // Assert
+            this.parentBinder.DidNotReceive().ResolveType(Arg.Any<string>());
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/StructBinder/FieldTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/StructBinder/FieldTests.cs
@@ -1,0 +1,50 @@
+namespace Thrift.Net.Tests.Compilation.Binding.StructBinder
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Model;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class FieldTests : StructBinderTests
+    {
+        private readonly IBinder fieldBinder = Substitute.For<IBinder>();
+
+        public FieldTests()
+        {
+            this.BinderProvider.GetBinder(default).ReturnsForAnyArgs(this.fieldBinder);
+        }
+
+        [Fact]
+        public void Bind_FieldsSupplied_UsesBinderToCreateFields()
+        {
+            // Arrange
+            var input =
+@"struct User {
+    1: i32 Id
+    2: string Username
+}";
+            var structContext = ParserInput
+                .FromString(input)
+                .ParseInput(parser => parser.structDefinition());
+
+            var idField = new FieldDefinition(
+                1, "1", FieldRequiredness.Default, FieldType.I32, "Id");
+            this.fieldBinder.Bind<FieldDefinition>(structContext.field()[0])
+                .Returns(idField);
+            var usernameField = new FieldDefinition(
+                2, "2", FieldRequiredness.Default, FieldType.I32, "Username");
+            this.fieldBinder.Bind<FieldDefinition>(structContext.field()[1])
+                .Returns(usernameField);
+
+            // Act
+            var structDefinition = this.Binder.Bind<StructDefinition>(structContext);
+
+            // Assert
+            Assert.Collection(
+                structDefinition.Fields,
+                id => Assert.Same(idField, id),
+                username => Assert.Same(usernameField, username));
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/StructBinder/GetPreviousSiblingTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/StructBinder/GetPreviousSiblingTests.cs
@@ -1,0 +1,94 @@
+namespace Thrift.Net.Tests.Compilation.Binding.StructBinder
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Model;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class GetPreviousSiblingTests : StructBinderTests
+    {
+        [Fact]
+        public void GetPreviousSibling_SiblingExists_ReturnsField()
+        {
+            // Arrange
+            var input =
+@"struct User {
+    i32 Id,
+    string User
+}";
+            var structNode = ParserInput
+                .FromString(input)
+                .ParseInput(parser => parser.structDefinition());
+
+            var fieldBinder = Substitute.For<IBinder>();
+            var fieldDefinition = new FieldDefinition(
+                0, "0", FieldRequiredness.Default, FieldType.I32, "Id");
+            fieldBinder.Bind<FieldDefinition>(structNode.field()[0])
+                .Returns(fieldDefinition);
+
+            this.BinderProvider.GetBinder(structNode.field()[0]).Returns(fieldBinder);
+
+            // Act
+            var sibling = this.Binder.GetPreviousSibling(structNode.field()[1]);
+
+            // Assert
+            Assert.Same(fieldDefinition, sibling);
+        }
+
+        [Fact]
+        public void GetPreviousSibling_NodeHasNoSiblings_ReturnsNull()
+        {
+            // Arrange
+            var input =
+@"struct User {
+    i32 Id
+}";
+            var structNode = ParserInput
+                .FromString(input)
+                .ParseInput(parser => parser.structDefinition());
+
+            var fieldBinder = Substitute.For<IBinder>();
+            var fieldDefinition = new FieldDefinition(
+                0, "0", FieldRequiredness.Default, FieldType.I32, "Id");
+            fieldBinder.Bind<FieldDefinition>(default)
+                .ReturnsForAnyArgs(fieldDefinition);
+
+            this.BinderProvider.GetBinder(default).ReturnsForAnyArgs(fieldBinder);
+
+            // Act
+            var sibling = this.Binder.GetPreviousSibling(structNode.field()[0]);
+
+            // Assert
+            Assert.Null(sibling);
+        }
+
+        [Fact]
+        public void GetPreviousSibling_NodeIsFirstSibling_ReturnsNull()
+        {
+            // Arrange
+            var input =
+@"struct User {
+    i32 Id,
+    string Username
+}";
+            var structNode = ParserInput
+                .FromString(input)
+                .ParseInput(parser => parser.structDefinition());
+
+            var fieldBinder = Substitute.For<IBinder>();
+            var fieldDefinition = new FieldDefinition(
+                0, "0", FieldRequiredness.Default, FieldType.I32, "Id");
+            fieldBinder.Bind<FieldDefinition>(default)
+                .ReturnsForAnyArgs(fieldDefinition);
+
+            this.BinderProvider.GetBinder(default).ReturnsForAnyArgs(fieldBinder);
+
+            // Act
+            var sibling = this.Binder.GetPreviousSibling(structNode.field()[0]);
+
+            // Assert
+            Assert.Null(sibling);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/StructBinder/IdentifierTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/StructBinder/IdentifierTests.cs
@@ -1,0 +1,39 @@
+namespace Thrift.Net.Tests.Compilation.Binding.StructBinder
+{
+    using Thrift.Net.Compilation.Model;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class IdentifierTests : StructBinderTests
+    {
+        [Fact]
+        public void Bind_StructNameSupplied_SetsName()
+        {
+            // Arrange
+            var structContext = ParserInput
+                .FromString("struct User {}")
+                .ParseInput(parser => parser.structDefinition());
+
+            // Act
+            var structDefinition = this.Binder.Bind<StructDefinition>(structContext);
+
+            // Assert
+            Assert.Equal("User", structDefinition.Name);
+        }
+
+        [Fact]
+        public void Bind_StructNameNotSupplied_Null()
+        {
+            // Arrange
+            var structContext = ParserInput
+                .FromString("struct {}")
+                .ParseInput(parser => parser.structDefinition());
+
+            // Act
+            var structDefinition = this.Binder.Bind<StructDefinition>(structContext);
+
+            // Assert
+            Assert.Null(structDefinition.Name);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Binding/StructBinder/StructBinderTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/StructBinder/StructBinderTests.cs
@@ -1,0 +1,19 @@
+namespace Thrift.Net.Tests.Compilation.Binding.StructBinder
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+
+    public abstract class StructBinderTests
+    {
+        public StructBinderTests()
+        {
+            this.Binder = new StructBinder(this.Parent, this.BinderProvider);
+        }
+
+        protected IBinder Parent { get; } = Substitute.For<IBinder>();
+
+        protected IBinderProvider BinderProvider { get; } = Substitute.For<IBinderProvider>();
+
+        protected StructBinder Binder { get; }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructParsingTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructParsingTests.cs
@@ -1,0 +1,68 @@
+namespace Thrift.Net.Tests.Compilation.ThriftCompiler
+{
+    using System.Linq;
+    using Thrift.Net.Tests.Extensions;
+    using Xunit;
+
+    using ThriftCompiler = Thrift.Net.Compilation.ThriftCompiler;
+
+    public class StructParsingTests
+    {
+        private readonly ThriftCompiler compiler = new ThriftCompiler();
+
+        [Fact]
+        public void Compile_DocumentContainsStruct_AddsStructToModel()
+        {
+            // Arrange
+            var input = "struct User {}";
+
+            // Act
+            var result = this.compiler.Compile(input.ToStream());
+
+            // Assert
+            Assert.Collection(
+                result.Document.Structs,
+                item => Assert.Equal("User", item.Name));
+        }
+
+        [Fact]
+        public void Compile_DocumentContainsMultipleStructs_AddsAllToModel()
+        {
+            // Arrange
+            var input =
+@"struct User {}
+struct Team {}";
+
+            // Act
+            var result = this.compiler.Compile(input.ToStream());
+
+            // Assert
+            Assert.Collection(
+                result.Document.Structs,
+                item => Assert.Equal("User", item.Name),
+                item => Assert.Equal("Team", item.Name));
+        }
+
+        [Fact]
+        public void Compile_StructContainsFields_AddsFieldsToStruct()
+        {
+            // Arrange
+            var input =
+@"struct User {
+    i32 Id
+    string Name
+}";
+
+            // Act
+            var result = this.compiler.Compile(input.ToStream());
+
+            // Assert
+            var definition = result.Document.Structs.First();
+
+            Assert.Collection(
+                definition.Fields,
+                item => Assert.Equal("Id", item.Name),
+                item => Assert.Equal("Name", item.Name));
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/ThriftDocumentGenerator/EnumGenerationTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftDocumentGenerator/EnumGenerationTests.cs
@@ -72,14 +72,17 @@ namespace Thrift.Net.Tests.Compilation.ThriftDocumentGenerator
 
         private static ThriftDocument CreateDocument()
         {
-            return new ThriftDocument("Thrift.Net.Tests", new List<EnumDefinition>
+            return new ThriftDocument(
+                "Thrift.Net.Tests",
+                new List<EnumDefinition>
                 {
                     new EnumDefinition("UserType", new List<EnumMember>
                     {
                         new EnumMember("User", 2),
                         new EnumMember("Administrator", 5),
                     }),
-                });
+                },
+                new List<StructDefinition>());
         }
     }
 }

--- a/src/Thrift.Net.Tests/Compilation/ThriftDocumentGenerator/NamespaceGenerationTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftDocumentGenerator/NamespaceGenerationTests.cs
@@ -13,7 +13,8 @@ namespace Thrift.Net.Tests.Compilation.ThriftDocumentGenerator
         {
             // Arrange
             var generator = new ThriftDocumentGenerator();
-            var document = new ThriftDocument("Thrift.Net.Tests", new List<EnumDefinition>());
+            var document = new ThriftDocument(
+                "Thrift.Net.Tests", new List<EnumDefinition>(), new List<StructDefinition>());
 
             // Act
             var output = generator.Generate(document);

--- a/src/Thrift.Net.Tests/Compiler/ProgramTests.cs
+++ b/src/Thrift.Net.Tests/Compiler/ProgramTests.cs
@@ -260,7 +260,7 @@ namespace Thrift.Net.Tests.Compiler
         private void SetupSuccessfulCompilation()
         {
             var compilationResult = new CompilationResult(
-                new ThriftDocument(null, new List<EnumDefinition>()),
+                new ThriftDocument(null, new List<EnumDefinition>(), new List<StructDefinition>()),
                 new List<CompilationMessage>());
 
             this.compiler.Compile(default).ReturnsForAnyArgs(compilationResult);
@@ -271,7 +271,7 @@ namespace Thrift.Net.Tests.Compiler
             var errorMessage = new CompilationMessage(
                 CompilerMessageId.EnumMustHaveAName, CompilerMessageType.Error, 1, 1, 1, null);
             var compilationResult = new CompilationResult(
-                new ThriftDocument(null, new List<EnumDefinition>()),
+                new ThriftDocument(null, new List<EnumDefinition>(), new List<StructDefinition>()),
                 new List<CompilationMessage> { errorMessage });
 
             this.compiler.Compile(default).ReturnsForAnyArgs(compilationResult);
@@ -282,7 +282,7 @@ namespace Thrift.Net.Tests.Compiler
             var errorMessage = new CompilationMessage(
                 CompilerMessageId.EnumMustHaveAName, CompilerMessageType.Warning, 1, 1, 1, null);
             var compilationResult = new CompilationResult(
-                new ThriftDocument(null, new List<EnumDefinition>()),
+                new ThriftDocument(null, new List<EnumDefinition>(), new List<StructDefinition>()),
                 new List<CompilationMessage> { errorMessage });
 
             this.compiler.Compile(default).ReturnsForAnyArgs(compilationResult);
@@ -291,7 +291,7 @@ namespace Thrift.Net.Tests.Compiler
         private void SetupCompilationWithMessages(params CompilationMessage[] messages)
         {
             var compilationResult = new CompilationResult(
-                new ThriftDocument(null, new List<EnumDefinition>()),
+                new ThriftDocument(null, new List<EnumDefinition>(), new List<StructDefinition>()),
                 messages);
 
             this.compiler.Compile(default).ReturnsForAnyArgs(compilationResult);

--- a/src/Thrift.Net.Tests/Utility/ParserInput.cs
+++ b/src/Thrift.Net.Tests/Utility/ParserInput.cs
@@ -1,6 +1,9 @@
 namespace Thrift.Net.Tests.Utility
 {
+    using System;
     using System.IO;
+    using Thrift.Net.Antlr;
+    using Thrift.Net.Compilation;
     using Thrift.Net.Tests.Extensions;
 
     /// <summary>
@@ -93,5 +96,12 @@ namespace Thrift.Net.Tests.Utility
         /// </summary>
         /// <returns>A stream created from the input string.</returns>
         public Stream GetStream() => this.Input.ToStream();
+
+        public TNode ParseInput<TNode>(Func<ThriftParser, TNode> parseMethod)
+        {
+            var parser = ThriftParserFactory.Create(this.GetStream());
+
+            return parseMethod(parser);
+        }
     }
 }

--- a/thrift-samples/structs/User.thrift
+++ b/thrift-samples/structs/User.thrift
@@ -1,0 +1,11 @@
+struct User {
+    1: required i32 Id
+    string Username
+    5: optional i8 I8Field
+    i16 I16Field
+    i64 I64Field
+    17: bool BoolField
+    byte ByteField
+    double DoubleField
+    binary BinaryField
+}


### PR DESCRIPTION
- Added the basic code necessary to parse structs. At the moment I've skipped implementing field
  defaults and some of the options that are Facebook-specific to reduce complexity.
- Began working on binding since I needed to be able to resolve the field types. This allowed me to
  split the code to convert nodes in the tree into symbols into multiple classes instead of
  continuing to add everything into the CompilationVisitor. I'll go through the other models in a
  future commit to create binders for them.
- Pulled the code to create a Thrift parser into ThriftParserFactory so the code could be shared
  with the tests, and updated ParserInput to make it easy to parse input in tests.