### PR TITLE
ci: don't run tests for docs only changes

### DIFF
--- a/pipelines/build-and-run-tests.yaml
+++ b/pipelines/build-and-run-tests.yaml
@@ -2,7 +2,14 @@ trigger:
 - master
 
 pr:
-- master
+  branches:
+    include:
+    - master
+  paths:
+    exclude:
+    # Don't run the pipeline for documentation-only changes
+    - '*.md'
+    - 'docs/**/*.md'
 
 pool:
   vmImage: 'ubuntu-latest'


### PR DESCRIPTION
- Updated the Build and Run Tests pipeline so that it doesn't run if the only thing that's changed
  is documentation.

Part of #46