### PR TITLE
ci: treat warnings as errors

### DIFF
--- a/pipelines/build-and-run-tests.yaml
+++ b/pipelines/build-and-run-tests.yaml
@@ -21,7 +21,7 @@ steps:
   inputs:
     command: 'test'
     projects: '$(System.DefaultWorkingDirectory)/src/Thrift.Net.Tests/Thrift.Net.Tests.csproj'
-    arguments: '--collect "XPlat Code Coverage"'
+    arguments: '--configuration Release -warnaserror /p:PublishSingleFile=false --collect "XPlat Code Coverage"'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish Code Coverage'


### PR DESCRIPTION
- Treat warnings as errors.
- Build and run tests in Release configuration.
- Disable publishing a single file because it doesn't work when running the tests. It fails with an
  error complaining about a missing runtime identifier, but adding the identifier doesn't get rid of
  the error.

Part of #46