### PR TITLE
feat(compiler): add support for lists

### DIFF
--- a/src/Thrift.Net.Antlr/Thrift.g4
+++ b/src/Thrift.Net.Antlr/Thrift.g4
@@ -49,9 +49,11 @@ field: (fieldType name=IDENTIFIER |
     fieldId=(INT_CONSTANT | IDENTIFIER | LITERAL)? ':' fieldRequiredness? fieldType name=IDENTIFIER) LIST_SEPARATOR?;
 
 fieldRequiredness: REQUIRED | OPTIONAL;
-fieldType: baseType | userType;
+fieldType: baseType | userType | collectionType;
 baseType: typeName=('bool' | 'byte' | 'i8' | 'i16' | 'i32' | 'i64' | 'double' | 'string' | 'binary' | 'slist');
 userType: IDENTIFIER;
+collectionType: listType;
+listType: 'list' '<' fieldType? '>';
 
 NAMESPACE: 'namespace';
 ENUM: 'enum';

--- a/src/Thrift.Net.Compilation/Binding/BaseTypeBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/BaseTypeBinder.cs
@@ -7,10 +7,10 @@ namespace Thrift.Net.Compilation.Binding
     /// Binds a <see cref="FieldTypeContext" /> node to a <see cref="BaseType" />
     /// object.
     /// </summary>
-    public class BaseTypeBinder : Binder<BaseTypeContext, BaseType, IField>
+    public class BaseTypeBinder : Binder<BaseTypeContext, BaseType, ISymbol>
     {
         /// <inheritdoc />
-        protected override BaseType Bind(BaseTypeContext node, IField parent)
+        protected override BaseType Bind(BaseTypeContext node, ISymbol parent)
         {
             return BaseType.Resolve(node, parent);
         }

--- a/src/Thrift.Net.Compilation/Binding/BinderProvider.cs
+++ b/src/Thrift.Net.Compilation/Binding/BinderProvider.cs
@@ -20,6 +20,7 @@ namespace Thrift.Net.Compilation.Binding
         private static readonly FieldTypeBinder FieldTypeBinder;
         private static readonly BaseTypeBinder BaseTypeBinder;
         private static readonly UserTypeBinder UserTypeBinder;
+        private static readonly ListTypeBinder ListTypeBinder;
         private static readonly BinderProvider ProviderInstance;
 
         static BinderProvider()
@@ -34,6 +35,7 @@ namespace Thrift.Net.Compilation.Binding
             FieldTypeBinder = new FieldTypeBinder(ProviderInstance);
             BaseTypeBinder = new BaseTypeBinder();
             UserTypeBinder = new UserTypeBinder();
+            ListTypeBinder = new ListTypeBinder(ProviderInstance);
         }
 
         private BinderProvider()
@@ -92,6 +94,10 @@ namespace Thrift.Net.Compilation.Binding
             else if (node is UserTypeContext)
             {
                 return UserTypeBinder;
+            }
+            else if (node is ListTypeContext)
+            {
+                return ListTypeBinder;
             }
 
             throw new ArgumentException(

--- a/src/Thrift.Net.Compilation/Binding/FieldTypeBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/FieldTypeBinder.cs
@@ -6,7 +6,7 @@ namespace Thrift.Net.Compilation.Binding
     /// <summary>
     /// Used to bind the type of fields.
     /// </summary>
-    public class FieldTypeBinder : Binder<FieldTypeContext, IFieldType, IField>
+    public class FieldTypeBinder : Binder<FieldTypeContext, IFieldType, ISymbol>
     {
         private readonly IBinderProvider binderProvider;
 
@@ -20,7 +20,7 @@ namespace Thrift.Net.Compilation.Binding
         }
 
         /// <inheritdoc />
-        protected override IFieldType Bind(FieldTypeContext node, IField parent)
+        protected override IFieldType Bind(FieldTypeContext node, ISymbol parent)
         {
             if (node.baseType() != null)
             {
@@ -29,9 +29,16 @@ namespace Thrift.Net.Compilation.Binding
                     .Bind<IFieldType>(node.baseType(), parent);
             }
 
+            if (node.userType() != null)
+            {
+                return this.binderProvider
+                    .GetBinder(node.userType())
+                    .Bind<IFieldType>(node.userType(), parent);
+            }
+
             return this.binderProvider
-                .GetBinder(node.userType())
-                .Bind<IFieldType>(node.userType(), parent);
+                .GetBinder(node.collectionType().listType())
+                .Bind<IFieldType>(node.collectionType().listType(), parent);
         }
     }
 }

--- a/src/Thrift.Net.Compilation/Binding/ListTypeBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/ListTypeBinder.cs
@@ -1,0 +1,29 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using Thrift.Net.Compilation.Symbols;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Used to bind <see cref="ListType" /> objects from <see cref="ListTypeContext" />
+    /// nodes.
+    /// </summary>
+    public class ListTypeBinder : Binder<ListTypeContext, ListType, ISymbol>
+    {
+        private readonly IBinderProvider binderProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListTypeBinder" /> class.
+        /// </summary>
+        /// <param name="binderProvider">Used to get binders.</param>
+        public ListTypeBinder(IBinderProvider binderProvider)
+        {
+            this.binderProvider = binderProvider;
+        }
+
+        /// <inheritdoc/>
+        protected override ListType Bind(ListTypeContext node, ISymbol parent)
+        {
+            return new ListType(node, parent, this.binderProvider);
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/UserTypeBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/UserTypeBinder.cs
@@ -7,10 +7,10 @@ namespace Thrift.Net.Compilation.Binding
     /// <summary>
     /// Used to bind <see cref="IUserType" /> objects.
     /// </summary>
-    public class UserTypeBinder : Binder<UserTypeContext, IUserType, IField>
+    public class UserTypeBinder : Binder<UserTypeContext, IUserType, ISymbol>
     {
         /// <inheritdoc/>
-        protected override IUserType Bind(UserTypeContext node, IField parent)
+        protected override IUserType Bind(UserTypeContext node, ISymbol parent)
         {
             var type = parent.ResolveType(node.IDENTIFIER().Symbol.Text);
             if (type == null)

--- a/src/Thrift.Net.Compilation/Symbols/BaseType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/BaseType.cs
@@ -7,7 +7,7 @@ namespace Thrift.Net.Compilation.Symbols
     /// <summary>
     /// Represents a Thrift Base type (string, bool, i32, etc).
     /// </summary>
-    public class BaseType : Symbol<BaseTypeContext, IField>, IBaseType
+    public class BaseType : Symbol<BaseTypeContext, ISymbol>, IBaseType
     {
         /// <summary>
         /// The name of the byte type.
@@ -80,17 +80,17 @@ namespace Thrift.Net.Compilation.Symbols
         /// Initializes a new instance of the <see cref="BaseType" /> class.
         /// </summary>
         /// <param name="context">The node this symbol is being created from.</param>
-        /// <param name="field">The field that this is the type for.</param>
+        /// <param name="parent">The parent symbol.</param>
         /// <param name="name">The name of the type.</param>
         /// <param name="requiredTypeName">The C# type name to use for required fields.</param>
         /// <param name="optionalTypeName">The C# type name to use for optional fields.</param>
         public BaseType(
             BaseTypeContext context,
-            IField field,
+            ISymbol parent,
             string name,
             string requiredTypeName,
             string optionalTypeName)
-            : base(context, field)
+            : base(context, parent)
         {
             this.Name = name;
             this.CSharpRequiredTypeName = requiredTypeName;
@@ -124,6 +124,9 @@ namespace Thrift.Net.Compilation.Symbols
         /// <inheritdoc />
         public bool IsEnum => false;
 
+        /// <inheritdoc/>
+        public bool IsList => false;
+
         /// <summary>
         /// Resolves the specified node into a base type.
         /// </summary>
@@ -133,7 +136,7 @@ namespace Thrift.Net.Compilation.Symbols
         /// <exception cref="InvalidOperationException">
         /// Thrown if the specified type is unknown.
         /// </exception>
-        public static BaseType Resolve(BaseTypeContext node, IField parent)
+        public static BaseType Resolve(BaseTypeContext node, ISymbol parent)
         {
             return node.typeName.Text switch
             {

--- a/src/Thrift.Net.Compilation/Symbols/Builders/ListTypeBuilder.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Builders/ListTypeBuilder.cs
@@ -1,0 +1,19 @@
+namespace Thrift.Net.Compilation.Symbols.Builders
+{
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Builds <see cref="ListType" /> objects.
+    /// </summary>
+    public class ListTypeBuilder : SymbolBuilder<ListTypeContext, ListType, ISymbol, ListTypeBuilder>
+    {
+        /// <inheritdoc/>
+        public override ListType Build()
+        {
+            return new ListType(
+                this.Node,
+                this.Parent,
+                this.BinderProvider);
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Symbols/Builders/UserTypeBuilder.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Builders/UserTypeBuilder.cs
@@ -5,7 +5,7 @@ namespace Thrift.Net.Compilation.Symbols.Builders
     /// <summary>
     /// Builds <see cref="UserType" /> objects.
     /// </summary>
-    public class UserTypeBuilder : SymbolBuilder<UserTypeContext, UserType, IField, UserTypeBuilder>
+    public class UserTypeBuilder : SymbolBuilder<UserTypeContext, UserType, ISymbol, UserTypeBuilder>
     {
         private INamedTypeSymbol definition;
 

--- a/src/Thrift.Net.Compilation/Symbols/IFieldType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/IFieldType.cs
@@ -40,5 +40,10 @@ namespace Thrift.Net.Compilation.Symbols
         /// Gets a value indicating whether the type is an enum.
         /// </summary>
         public bool IsEnum { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the type is a list.
+        /// </summary>
+        public bool IsList { get; }
     }
 }

--- a/src/Thrift.Net.Compilation/Symbols/IListType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/IListType.cs
@@ -1,0 +1,13 @@
+namespace Thrift.Net.Compilation.Symbols
+{
+    /// <summary>
+    /// Represents a Thrift list.
+    /// </summary>
+    public interface IListType : IFieldType
+    {
+        /// <summary>
+        /// Gets the type of element this list contains.
+        /// </summary>
+        IFieldType ElementType { get; }
+    }
+}

--- a/src/Thrift.Net.Compilation/Symbols/IUserType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/IUserType.cs
@@ -5,7 +5,7 @@ namespace Thrift.Net.Compilation.Symbols
     /// <summary>
     /// Represents a user-defined type like a struct or enum.
     /// </summary>
-    public interface IUserType : ISymbol<UserTypeContext, IField>, IFieldType
+    public interface IUserType : ISymbol<UserTypeContext, ISymbol>, IFieldType
     {
     }
 }

--- a/src/Thrift.Net.Compilation/Symbols/ListType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/ListType.cs
@@ -1,0 +1,102 @@
+namespace Thrift.Net.Compilation.Symbols
+{
+    using System;
+    using Thrift.Net.Compilation.Binding;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Represents a Thrift list.
+    /// </summary>
+    public class ListType : Symbol<ListTypeContext, ISymbol>, IListType
+    {
+        private readonly IBinderProvider binderProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListType" /> class.
+        /// </summary>
+        /// <param name="node">The node the symbol was created from.</param>
+        /// <param name="parent">The parent of this type.</param>
+        /// <param name="binderProvider">Used to get binders.</param>
+        public ListType(ListTypeContext node, ISymbol parent, IBinderProvider binderProvider)
+            : base(node, parent)
+        {
+            this.binderProvider = binderProvider;
+        }
+
+        /// <inheritdoc/>
+        public IFieldType ElementType
+        {
+            get
+            {
+                if (this.Node.fieldType() != null)
+                {
+                    return this.binderProvider
+                        .GetBinder(this.Node.fieldType())
+                        .Bind<IFieldType>(this.Node.fieldType(), this);
+                }
+
+                return null;
+            }
+        }
+
+        /// <inheritdoc/>
+        public string Name => $"list<{this.ElementType?.Name}>";
+
+        /// <inheritdoc/>
+        public bool IsResolved => true;
+
+        /// <inheritdoc/>
+        public string CSharpOptionalTypeName => this.GetTypeName();
+
+        /// <inheritdoc/>
+        public string CSharpRequiredTypeName => this.GetTypeName();
+
+        /// <inheritdoc/>
+        public bool IsBaseType => false;
+
+        /// <inheritdoc/>
+        public bool IsStruct => false;
+
+        /// <inheritdoc/>
+        public bool IsEnum => false;
+
+        /// <inheritdoc/>
+        public bool IsList => true;
+
+        /// <summary>
+        /// Gets the level of nesting of this list. A top level list returns null,
+        /// and each inner list type returns an increasing number starting at 1 to
+        /// indicate how deeply nested the list is.
+        /// </summary>
+        public int? NestingDepth
+        {
+            get
+            {
+                if (this.Parent is IListType)
+                {
+                    var depth = 1;
+                    var parent = this.Parent;
+                    while (parent.Parent is IListType)
+                    {
+                        parent = parent.Parent;
+                        depth++;
+                    }
+
+                    return depth;
+                }
+
+                return null;
+            }
+        }
+
+        private string GetTypeName()
+        {
+            if (this.ElementType != null)
+            {
+                return $"System.Collections.Generic.List<{this.ElementType.CSharpRequiredTypeName}>";
+            }
+
+            throw new InvalidOperationException("Cannot get the type name because no element type was provided.");
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Symbols/UserType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/UserType.cs
@@ -6,7 +6,7 @@ namespace Thrift.Net.Compilation.Symbols
     /// <summary>
     /// Represents a user-defined type like an enum, struct, etc.
     /// </summary>
-    public class UserType : Symbol<UserTypeContext, IField>, IUserType
+    public class UserType : Symbol<UserTypeContext, ISymbol>, IUserType
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UserType" /> class.
@@ -16,7 +16,7 @@ namespace Thrift.Net.Compilation.Symbols
         /// <param name="definition">The symbol representing the type definition.</param>
         public UserType(
             UserTypeContext node,
-            IField parent,
+            ISymbol parent,
             INamedTypeSymbol definition)
             : base(node, parent)
         {
@@ -74,6 +74,9 @@ namespace Thrift.Net.Compilation.Symbols
 
         /// <inheritdoc/>
         public bool IsBaseType => false;
+
+        /// <inheritdoc/>
+        public bool IsList => false;
 
         private string GetOptionalTypeName()
         {

--- a/src/Thrift.Net.Compilation/Templates/csharp.stg
+++ b/src/Thrift.Net.Compilation/Templates/csharp.stg
@@ -186,23 +186,10 @@ public bool $field.Name$;
 
 generateReadFieldCaseStatement(field, typeMap) ::= <<
 case FieldIds.$field.Name$:
-$if(field.Type.IsBaseType)$
-    if (field.Type == $typeMap.(field.Type.Name).TypeName$)
+    if (field.Type == $getTType(field.Type, typeMap)$)
     {
-        this.$field.Name$ = await protocol.$typeMap.(field.Type.Name).ReadMethodName$(cancellationToken);
+        $generateReadMethod(qualifyWithThis(field.Name), field.Type, typeMap, false)$
     }
-$elseif(field.Type.IsEnum)$
-    if (field.Type == TType.I32)
-    {
-        this.$field.Name$ = ($field.Type.CSharpRequiredTypeName$)await protocol.ReadI32Async(cancellationToken);
-    }
-$else$
-    if (field.Type == TType.Struct)
-    {
-        this.$field.Name$ = new $field.Type.CSharpRequiredTypeName$();
-        await this.$field.Name$.ReadAsync(protocol, cancellationToken);
-    }
-$endif$
     else
     {
         await TProtocolUtil.SkipAsync(protocol, field.Type, cancellationToken);
@@ -211,27 +198,108 @@ $endif$
     break;
 >>
 
+generateReadMethod(variableName, type, typeMap, isNested) ::= <%
+$if(type.IsBaseType)$
+    $generateBaseTypeReadMethod(variableName, type, typeMap, isNested)$
+$elseif(type.IsEnum)$
+    $generateEnumReadMethod(variableName, type, isNested)$
+$elseif(type.IsStruct)$
+    $generateStructReadMethod(variableName, type, isNested)$
+$else$
+    $generateListReadMethod(variableName, type, typeMap, isNested)$
+$endif$
+%>
+
+generateBaseTypeReadMethod(variableName, type, typeMap, isNested) ::= <<
+$if(isNested)$var $endif$$variableName$ = await protocol.$typeMap.(type.Name).ReadMethodName$(cancellationToken);
+>>
+
+generateEnumReadMethod(variableName, type, isNested) ::= <<
+$if(isNested)$var $endif$$variableName$ = ($type.CSharpRequiredTypeName$)await protocol.ReadI32Async(cancellationToken);
+>>
+
+generateStructReadMethod(variableName, type, isNested) ::= <<
+$if(isNested)$var $endif$$variableName$ = new $type.CSharpRequiredTypeName$();
+await $variableName$.ReadAsync(protocol, cancellationToken);
+>>
+
+generateListReadMethod(variableName, type, typeMap, isNested) ::= <<
+var $getListVariableName("listInfo", type.NestingDepth)$ = await protocol.ReadListBeginAsync(cancellationToken);
+$if(isNested)$var $endif$$variableName$ = new $type.CSharpRequiredTypeName$($getListVariableName("listInfo", type.NestingDepth)$.Count);
+
+for (var $getListVariableName("i", type.NestingDepth)$ = 0; $getListVariableName("i", type.NestingDepth)$ < $getListVariableName("listInfo", type.NestingDepth)$.Count; $getListVariableName("i", type.NestingDepth)$++)
+{
+    $generateReadMethod(getListVariableName("element", type.NestingDepth), type.ElementType, typeMap, true)$
+    $variableName$.Add($getListVariableName("element", type.NestingDepth)$);
+}
+
+await protocol.ReadListEndAsync(cancellationToken);
+>>
+
+getTType(type, typeMap) ::= <%
+$if(type.IsBaseType)$
+    $typeMap.(type.Name).TypeName$
+$elseif(type.IsEnum)$
+    TType.I32
+$elseif(type.IsStruct)$
+    TType.Struct
+$else$
+    TType.List
+$endif$
+%>
+
+getListVariableName(name, nestingDepth) ::= <%
+$name$$nestingDepth$
+%>
+
+generateBaseTypeWriteMethod(variableName, type, typeMap) ::= <%
+await protocol.$typeMap.(type.Name).WriteMethodName$($variableName$ ?? default, cancellationToken);
+%>
+
+generateEnumWriteMethod(variableName) ::= <%
+await protocol.WriteI32Async((int)$variableName$, cancellationToken);
+%>
+
+generateStructWriteMethod(variableName) ::= <%
+await $variableName$.WriteAsync(protocol, cancellationToken);
+%>
+
+generateListWriteMethod(variableName, type, typeMap) ::= <<
+await protocol.WriteListBeginAsync(new TList($getTType(type.ElementType, typeMap)$, $variableName$.Count), cancellationToken);
+
+foreach (var $getListVariableName("element", type.NestingDepth)$ in $variableName$)
+{
+    $generateWriteMethod(getListVariableName("element", type.NestingDepth), type.ElementType, typeMap)$
+}
+
+await protocol.WriteListEndAsync(cancellationToken);
+>>
+
+generateWriteMethod(variableName, type, typeMap) ::= <%
+$if(type.IsBaseType)$
+    $generateBaseTypeWriteMethod(variableName, type, typeMap)$
+$elseif(type.IsEnum)$
+    $generateEnumWriteMethod(variableName)$
+$elseif(type.IsStruct)$
+    $generateStructWriteMethod(variableName)$
+$else$
+    $generateListWriteMethod(variableName, type, typeMap)$
+$endif$
+%>
+
+qualifyWithThis(name) ::= <%
+this.$name$
+%>
+
 generateWriteField(field, typeMap) ::= <<
 if (this.$field.Name$ != null && this.IsSet.$field.Name$)
 {
     field.Name = "$field.Name$";
     field.ID = FieldIds.$field.Name$;
-$if(field.Type.IsBaseType)$
-    field.Type = $typeMap.(field.Type.Name).TypeName$;
-$elseif(field.Type.IsEnum)$
-    field.Type = TType.I32;
-$else$
-    field.Type = TType.Struct;
-$endif$
+    field.Type = $getTType(field.Type, typeMap)$;
 
     await protocol.WriteFieldBeginAsync(field, cancellationToken);
-$if(field.Type.IsBaseType)$
-    await protocol.$typeMap.(field.Type.Name).WriteMethodName$(this.$field.Name$ ?? default, cancellationToken);
-$elseif(field.Type.IsEnum)$
-    await protocol.WriteI32Async((int)this.$field.Name$, cancellationToken);
-$else$
-    await this.$field.Name$.WriteAsync(protocol, cancellationToken);
-$endif$
+    $generateWriteMethod(qualifyWithThis(field.Name), field.Type, typeMap)$
     await protocol.WriteFieldEndAsync(cancellationToken);
 }
 >>

--- a/src/Thrift.Net.Tests/Compilation/Binding/FieldTypeBinder/FieldTypeBinderTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/FieldTypeBinder/FieldTypeBinderTests.cs
@@ -57,5 +57,27 @@ namespace Thrift.Net.Tests.Compilation.Binding.FieldTypeBinder
             // Assert
             Assert.Same(userType, type);
         }
+
+        [Fact]
+        public void Bind_ListType_ResolvesType()
+        {
+            // Arrange
+            var field = new FieldBuilder().Build();
+            var node = ParserInput
+                .FromString("list<string>")
+                .ParseInput(parser => parser.fieldType());
+
+            this.binderProvider.GetBinder(node.collectionType().listType())
+                .Returns(this.typeBinder);
+            var listType = Substitute.For<IListType>();
+            this.typeBinder.Bind<IFieldType>(node.collectionType().listType(), field)
+                .Returns(listType);
+
+            // Act
+            var type = this.binder.Bind<IFieldType>(node, field);
+
+            // Assert
+            Assert.Same(listType, type);
+        }
     }
 }

--- a/src/Thrift.Net.Tests/Compilation/Symbols/ListType/CSharpOptionalTypeNameTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/ListType/CSharpOptionalTypeNameTests.cs
@@ -1,0 +1,65 @@
+namespace Thrift.Net.Tests.Compilation.Symbols.ListType
+{
+    using System;
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Symbols;
+    using Thrift.Net.Compilation.Symbols.Builders;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class CSharpOptionalTypeNameTests
+    {
+        private readonly IField field = Substitute.For<IField>();
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+        private readonly IBinder elementBinder = Substitute.For<IBinder>();
+
+        [Fact]
+        public void ElementExists_IncludesElementTypeInName()
+        {
+            // Arrange
+            var node = ParserInput
+                .FromString("list<string>")
+                .ParseInput(parser => parser.listType());
+
+            var listType = new ListTypeBuilder()
+                .SetNode(node)
+                .SetParent(this.field)
+                .SetBinderProvider(this.binderProvider)
+                .Build();
+
+            var elementType = Substitute.For<IFieldType>();
+            elementType.CSharpRequiredTypeName.Returns("string");
+
+            this.binderProvider.GetBinder(node.fieldType()).Returns(this.elementBinder);
+            this.elementBinder.Bind<IFieldType>(node.fieldType(), listType).Returns(elementType);
+
+            // Act
+            var name = listType.CSharpOptionalTypeName;
+
+            // Assert
+            Assert.Equal("System.Collections.Generic.List<string>", name);
+        }
+
+        [Fact]
+        public void ElementNotSpecified_ThrowsException()
+        {
+            // Arrange
+            var node = ParserInput
+                .FromString("list<>")
+                .ParseInput(parser => parser.listType());
+
+            var listType = new ListTypeBuilder()
+                .SetNode(node)
+                .SetParent(this.field)
+                .SetBinderProvider(this.binderProvider)
+                .Build();
+
+            this.binderProvider.GetBinder(node.fieldType()).Returns(this.elementBinder);
+            this.elementBinder.Bind<IFieldType>(node.fieldType(), listType).Returns((IFieldType)null);
+
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => listType.CSharpOptionalTypeName);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Symbols/ListType/CSharpRequiredTypeNameTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/ListType/CSharpRequiredTypeNameTests.cs
@@ -1,0 +1,65 @@
+namespace Thrift.Net.Tests.Compilation.Symbols.ListType
+{
+    using System;
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Symbols;
+    using Thrift.Net.Compilation.Symbols.Builders;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class CSharpRequiredTypeNameTests
+    {
+        private readonly IField field = Substitute.For<IField>();
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+        private readonly IBinder elementBinder = Substitute.For<IBinder>();
+
+        [Fact]
+        public void ElementExists_IncludesElementTypeInName()
+        {
+            // Arrange
+            var node = ParserInput
+                .FromString("list<string>")
+                .ParseInput(parser => parser.listType());
+
+            var listType = new ListTypeBuilder()
+                .SetNode(node)
+                .SetParent(this.field)
+                .SetBinderProvider(this.binderProvider)
+                .Build();
+
+            var elementType = Substitute.For<IFieldType>();
+            elementType.CSharpRequiredTypeName.Returns("string");
+
+            this.binderProvider.GetBinder(node.fieldType()).Returns(this.elementBinder);
+            this.elementBinder.Bind<IFieldType>(node.fieldType(), listType).Returns(elementType);
+
+            // Act
+            var name = listType.CSharpRequiredTypeName;
+
+            // Assert
+            Assert.Equal("System.Collections.Generic.List<string>", name);
+        }
+
+        [Fact]
+        public void ElementNotSpecified_ThrowsException()
+        {
+            // Arrange
+            var node = ParserInput
+                .FromString("list<>")
+                .ParseInput(parser => parser.listType());
+
+            var listType = new ListTypeBuilder()
+                .SetNode(node)
+                .SetParent(this.field)
+                .SetBinderProvider(this.binderProvider)
+                .Build();
+
+            this.binderProvider.GetBinder(node.fieldType()).Returns(this.elementBinder);
+            this.elementBinder.Bind<IFieldType>(node.fieldType(), listType).Returns((IFieldType)null);
+
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => listType.CSharpRequiredTypeName);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Symbols/ListType/NameTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/ListType/NameTests.cs
@@ -1,0 +1,67 @@
+namespace Thrift.Net.Tests.Compilation.Symbols.ListType
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Symbols;
+    using Thrift.Net.Compilation.Symbols.Builders;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class NameTests
+    {
+        private readonly IField field = Substitute.For<IField>();
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+        private readonly IBinder elementBinder = Substitute.For<IBinder>();
+
+        [Fact]
+        public void ElementExists_IncludesElementTypeInName()
+        {
+            // Arrange
+            var node = ParserInput
+                .FromString("list<string>")
+                .ParseInput(parser => parser.listType());
+
+            var listType = new ListTypeBuilder()
+                .SetNode(node)
+                .SetParent(this.field)
+                .SetBinderProvider(this.binderProvider)
+                .Build();
+
+            var elementType = Substitute.For<IFieldType>();
+            elementType.Name.Returns("string");
+
+            this.binderProvider.GetBinder(node.fieldType()).Returns(this.elementBinder);
+            this.elementBinder.Bind<IFieldType>(node.fieldType(), listType).Returns(elementType);
+
+            // Act
+            var name = listType.Name;
+
+            // Assert
+            Assert.Equal("list<string>", name);
+        }
+
+        [Fact]
+        public void ElementNotSpecified_DoesNotIncludeElementTypeInName()
+        {
+            // Arrange
+            var node = ParserInput
+                .FromString("list<>")
+                .ParseInput(parser => parser.listType());
+
+            var listType = new ListTypeBuilder()
+                .SetNode(node)
+                .SetParent(this.field)
+                .SetBinderProvider(this.binderProvider)
+                .Build();
+
+            this.binderProvider.GetBinder(node.fieldType()).Returns(this.elementBinder);
+            this.elementBinder.Bind<IFieldType>(node.fieldType(), listType).Returns((IFieldType)null);
+
+            // Act
+            var name = listType.Name;
+
+            // Assert
+            Assert.Equal("list<>", name);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Symbols/ListType/NestingDepthTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/ListType/NestingDepthTests.cs
@@ -1,0 +1,63 @@
+namespace Thrift.Net.Tests.Compilation.Symbols.ListType
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Symbols;
+    using Thrift.Net.Compilation.Symbols.Builders;
+    using Xunit;
+
+    public class NestingDepthTests
+    {
+        [Fact]
+        public void TopLevelList_ReturnsNull()
+        {
+            // Arrange
+            var field = Substitute.For<ISymbol>();
+            var type = new ListTypeBuilder()
+                .SetParent(field)
+                .Build();
+
+            // Act
+            var nestingDepth = type.NestingDepth;
+
+            // Assert
+            Assert.Null(nestingDepth);
+        }
+
+        [Fact]
+        public void ListIsNested_ReturnsOne()
+        {
+            // Arrange
+            var parent = Substitute.For<IListType>();
+            var type = new ListTypeBuilder()
+                .SetParent(parent)
+                .Build();
+
+            // Act
+            var nestingDepth = type.NestingDepth;
+
+            // Assert
+            Assert.Equal(1, nestingDepth);
+        }
+
+        [Fact]
+        public void ListIsNestedMultipleLevelsDeep_ReturnsNestingLevel()
+        {
+            // Arrange
+            // Simulate List<List<List<T>>>
+            var field = Substitute.For<IField>();
+            var type = new ListTypeBuilder() // List<>
+                .SetParent(new ListTypeBuilder() // List<List<>>
+                    .SetParent(new ListTypeBuilder() // List<List<List<>>>
+                        .SetParent(field)
+                        .Build())
+                    .Build())
+                .Build();
+
+            // Act
+            var nestingDepth = type.NestingDepth;
+
+            // Assert
+            Assert.Equal(2, nestingDepth);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructParsingTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructParsingTests.cs
@@ -1,6 +1,7 @@
 namespace Thrift.Net.Tests.Compilation.ThriftCompiler
 {
     using System.Linq;
+    using Thrift.Net.Compilation.Symbols;
     using Thrift.Net.Tests.Extensions;
     using Xunit;
 
@@ -178,6 +179,26 @@ struct User {
                 f => f.Name == "Type");
 
             Assert.Equal("UserType", field.Type.Name);
+        }
+
+        [Fact]
+        public void Compile_StructHasList_ParsesList()
+        {
+            // Arrange
+            var input =
+@"struct User {
+    1: list<string> Emails
+}";
+
+            // Act
+            var result = this.compiler.Compile(input.ToStream());
+
+            // Assert
+            var field = result.Document.Structs.Single().Fields.FirstOrDefault(
+                f => f.Name == "Emails");
+
+            var list = Assert.IsType<ListType>(field.Type);
+            Assert.Equal(BaseType.String, list.ElementType.Name);
         }
     }
 }

--- a/thrift-samples/collections.thrift
+++ b/thrift-samples/collections.thrift
@@ -1,0 +1,7 @@
+struct User {
+    0: i32 Id,
+    1: list<string> Emails,
+    2: list<Address> Addresses,
+    3: list<> SomeList
+    4: list<list<Address>> NestedList
+}


### PR DESCRIPTION
- Added a new `ListType` that represents a list. It contains an `ElementType`, which is resolved
  using the `FieldTypeBinder`. This means that the element of a list can be any other type (e.g.
  struct, enum, another list, etc.
- In order to generate valid code, I had to add a `NestingDepth` property. This is used to make sure
  the variable names generated for iterating over the lists are unique in the case of nested lists.
- In order to support calculating the nesting depth, I had to alter the type of the Parent of
  `BaseType`, `UserType` and `ListType` to be `ISymbol` instead of `IField`. This allows a list to
  container another list.
- At the moment I've just chosen to fully qualify the `List<T>` class rather than adding a using
  statement, but I might take a look at that in a further change.

Part of #11