### PR TITLE
fix(compiler): ignore IsSet for required fields

### DIFF
--- a/src/Thrift.Net.Compilation/Templates/csharp.stg
+++ b/src/Thrift.Net.Compilation/Templates/csharp.stg
@@ -171,7 +171,9 @@ public $getFieldType(field)$ $field.Name$
     set
     {
         this.$backingFieldName(field)$ = value;
+        $if(!field.IsRequired)$
         this.isSet.$field.Name$ = value != null;
+        $endif$
     }
 }
 >>
@@ -292,14 +294,18 @@ this.$name$
 %>
 
 generateWriteField(field, typeMap) ::= <<
-if (this.$field.Name$ != null && this.IsSet.$field.Name$)
+$if(field.IsRequired)$$generateWriteFieldInner(field, typeMap)$$else$if (this.$field.Name$ != null && this.IsSet.$field.Name$)
 {
-    field.Name = "$field.Name$";
-    field.ID = FieldIds.$field.Name$;
-    field.Type = $getTType(field.Type, typeMap)$;
+    $generateWriteFieldInner(field, typeMap)$
+}$endif$
+>>
 
-    await protocol.WriteFieldBeginAsync(field, cancellationToken);
-    $generateWriteMethod(qualifyWithThis(field.Name), field.Type, typeMap)$
-    await protocol.WriteFieldEndAsync(cancellationToken);
-}
+generateWriteFieldInner(field, typeMap) ::= <<
+field.Name = "$field.Name$";
+field.ID = FieldIds.$field.Name$;
+field.Type = $getTType(field.Type, typeMap)$;
+
+await protocol.WriteFieldBeginAsync(field, cancellationToken);
+$generateWriteMethod(qualifyWithThis(field.Name), field.Type, typeMap)$
+await protocol.WriteFieldEndAsync(cancellationToken);
 >>


### PR DESCRIPTION
- Updated the template to stop it setting `IsSet` when a property is set, or checking whether a
  field is set or not before writing it for required fields. This was causing a compilation error
  because no IsSet field is generated for required fields.

  Part of #11