### PR TITLE
feat(compiler): list element type missing error

### DIFF
--- a/src/Thrift.Net.Antlr/Thrift.g4
+++ b/src/Thrift.Net.Antlr/Thrift.g4
@@ -53,13 +53,15 @@ fieldType: baseType | userType | collectionType;
 baseType: typeName=('bool' | 'byte' | 'i8' | 'i16' | 'i32' | 'i64' | 'double' | 'string' | 'binary' | 'slist');
 userType: IDENTIFIER;
 collectionType: listType;
-listType: 'list' '<' fieldType? '>';
+listType: 'list' LT_OPERATOR fieldType? GT_OPERATOR;
 
 NAMESPACE: 'namespace';
 ENUM: 'enum';
 STRUCT: 'struct';
 REQUIRED: 'required';
 OPTIONAL: 'optional';
+LT_OPERATOR: '<';
+GT_OPERATOR: '>';
 KNOWN_NAMESPACE_SCOPES: '*' | 'c_glib' | 'cpp' | 'csharp' | 'delphi' | 'go' |
     'java' | 'js' | 'lua' | 'netcore' | 'netstd' | 'perl' | 'php' | 'py' |
     'py.twisted' | 'rb' | 'st' | 'xsd';

--- a/src/Thrift.Net.Compilation/CompilationVisitor.cs
+++ b/src/Thrift.Net.Compilation/CompilationVisitor.cs
@@ -243,6 +243,20 @@ namespace Thrift.Net.Compilation
             base.VisitField(field);
         }
 
+        /// <inheritdoc/>
+        public override void VisitListType(IListType listType)
+        {
+            if (listType.ElementType == null)
+            {
+                this.AddError(
+                    CompilerMessageId.ListMustHaveElementTypeSpecified,
+                    listType.Node.LT_OPERATOR().Symbol,
+                    listType.Node.GT_OPERATOR().Symbol);
+            }
+
+            base.VisitListType(listType);
+        }
+
         private void AddEnumMessages(IEnum enumDefinition)
         {
             if (enumDefinition.Name == null)

--- a/src/Thrift.Net.Compilation/CompilerMessageId.cs
+++ b/src/Thrift.Net.Compilation/CompilerMessageId.cs
@@ -534,6 +534,27 @@ namespace Thrift.Net.Compilation
         FieldIdNotSpecified = 205,
 
         /// <summary>
+        /// A list has been declared, but no element type has been specified.
+        /// </summary>
+        /// <example>
+        /// The following example produces this warning:
+        /// <code>
+        /// struct User {
+        ///   1: list&lt;&gt; Emails
+        ///          ^^
+        /// }
+        /// </code>
+        ///
+        /// To fix this issue, specify an element type:
+        /// <code>
+        /// struct User {
+        ///   1: list&lt;string&gt; Emails
+        /// }
+        /// </code>
+        /// </example>
+        ListMustHaveElementTypeSpecified = 206,
+
+        /// <summary>
         /// A syntax error has been reported by the Antlr parser.
         /// </summary>
         /// <example>

--- a/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
+++ b/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
@@ -130,6 +130,9 @@
   <data name="TC0205" xml:space="preserve">
     <value>'{0}' does not have a field Id, which can lead to backwards-incompatible changes being made by accident. Please specify a field Id.</value>
   </data>
+  <data name="TC0206" xml:space="preserve">
+    <value>The list must have an element type specified.</value>
+  </data>
   <data name="TC0300" xml:space="preserve">
     <!-- Generic Antlr parsing error - just report the message from Antlr -->
     <value>{0}</value>

--- a/src/Thrift.Net.Compilation/Symbols/Field.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Field.cs
@@ -1,5 +1,6 @@
 namespace Thrift.Net.Compilation.Symbols
 {
+    using System.Collections.Generic;
     using Thrift.Net.Compilation.Binding;
     using static Thrift.Net.Antlr.ThriftParser;
 
@@ -76,6 +77,10 @@ namespace Thrift.Net.Compilation.Symbols
 
         /// <inheritdoc/>
         public bool IsFieldIdImplicit { get; }
+
+        /// <inheritdoc/>
+        protected override IReadOnlyCollection<ISymbol> Children =>
+            this.Type != null ? new List<ISymbol> { this.Type } : new List<ISymbol>();
 
         /// <inheritdoc/>
         public override void Accept(ISymbolVisitor visitor)

--- a/src/Thrift.Net.Compilation/Symbols/IListType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/IListType.cs
@@ -1,9 +1,11 @@
 namespace Thrift.Net.Compilation.Symbols
 {
+    using static Thrift.Net.Antlr.ThriftParser;
+
     /// <summary>
     /// Represents a Thrift list.
     /// </summary>
-    public interface IListType : IFieldType
+    public interface IListType : ISymbol<ListTypeContext, ISymbol>, IFieldType
     {
         /// <summary>
         /// Gets the type of element this list contains.

--- a/src/Thrift.Net.Compilation/Symbols/ISymbolVisitor.cs
+++ b/src/Thrift.Net.Compilation/Symbols/ISymbolVisitor.cs
@@ -40,5 +40,11 @@ namespace Thrift.Net.Compilation.Symbols
         /// </summary>
         /// <param name="struct">The struct to visit.</param>
         void VisitStruct(IStruct @struct);
+
+        /// <summary>
+        /// Visits a list type reference.
+        /// </summary>
+        /// <param name="listType">The list type being referenced by a field.</param>
+        void VisitListType(IListType listType);
     }
 }

--- a/src/Thrift.Net.Compilation/Symbols/ListType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/ListType.cs
@@ -1,6 +1,7 @@
 namespace Thrift.Net.Compilation.Symbols
 {
     using System;
+    using System.Collections.Generic;
     using Thrift.Net.Compilation.Binding;
     using static Thrift.Net.Antlr.ThriftParser;
 
@@ -87,6 +88,17 @@ namespace Thrift.Net.Compilation.Symbols
 
                 return null;
             }
+        }
+
+        /// <inheritdoc/>
+        protected override IReadOnlyCollection<ISymbol> Children =>
+            this.ElementType != null ? new List<ISymbol> { this.ElementType } : new List<ISymbol>();
+
+        /// <inheritdoc/>
+        public override void Accept(ISymbolVisitor visitor)
+        {
+            visitor.VisitListType(this);
+            base.Accept(visitor);
         }
 
         private string GetTypeName()

--- a/src/Thrift.Net.Compilation/Symbols/SymbolVisitor.cs
+++ b/src/Thrift.Net.Compilation/Symbols/SymbolVisitor.cs
@@ -34,5 +34,10 @@ namespace Thrift.Net.Compilation.Symbols
         public virtual void VisitStruct(IStruct @struct)
         {
         }
+
+        /// <inheritdoc/>
+        public virtual void VisitListType(IListType listType)
+        {
+        }
     }
 }

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructErrorTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructErrorTests.cs
@@ -79,5 +79,25 @@ CompilerMessageId.StructFieldIdMustBeAPositiveInteger,
 CompilerMessageId.UnknownType,
 "UserType");
         }
+
+        [Fact]
+        public void Compile_ListElementTypeNotSpecified_ReportsError()
+        {
+            this.AssertCompilerReturnsErrorMessage(
+@"struct User {
+    1: list$<>$ Emails
+}",
+CompilerMessageId.ListMustHaveElementTypeSpecified);
+        }
+
+        [Fact]
+        public void Compile_NestedListElementTypeNotSpecified_ReportsError()
+        {
+            this.AssertCompilerReturnsErrorMessage(
+@"struct User {
+    1: list<list$<>$> Addresses
+}",
+CompilerMessageId.ListMustHaveElementTypeSpecified);
+        }
     }
 }


### PR DESCRIPTION
- Added a new error message if a list is specified with no element type (`list<>`).

Part of #11