### PR TITLE
feat(compiler): list element type unresolved error

### DIFF
--- a/src/Thrift.Net.Compilation/CompilationVisitor.cs
+++ b/src/Thrift.Net.Compilation/CompilationVisitor.cs
@@ -226,20 +226,6 @@ namespace Thrift.Net.Compilation
                     field.Name);
             }
 
-            if (!field.Type.IsResolved)
-            {
-                // A field has referenced a type that doesn't exist. For example:
-                // ```
-                // struct User {
-                //     1: UserType Type
-                // }
-                // ```
-                this.AddError(
-                    CompilerMessageId.UnknownType,
-                    field.Node.fieldType().userType().IDENTIFIER().Symbol,
-                    field.Type.Name);
-            }
-
             base.VisitField(field);
         }
 
@@ -255,6 +241,26 @@ namespace Thrift.Net.Compilation
             }
 
             base.VisitListType(listType);
+        }
+
+        /// <inheritdoc/>
+        public override void VisitUserType(IUserType userType)
+        {
+            if (!userType.IsResolved)
+            {
+                // A field has referenced a type that doesn't exist. For example:
+                // ```
+                // struct User {
+                //     1: UserType Type
+                // }
+                // ```
+                this.AddError(
+                    CompilerMessageId.UnknownType,
+                    userType.Node.IDENTIFIER().Symbol,
+                    userType.Name);
+            }
+
+            base.VisitUserType(userType);
         }
 
         private void AddEnumMessages(IEnum enumDefinition)

--- a/src/Thrift.Net.Compilation/Symbols/ISymbolVisitor.cs
+++ b/src/Thrift.Net.Compilation/Symbols/ISymbolVisitor.cs
@@ -46,5 +46,11 @@ namespace Thrift.Net.Compilation.Symbols
         /// </summary>
         /// <param name="listType">The list type being referenced by a field.</param>
         void VisitListType(IListType listType);
+
+        /// <summary>
+        /// Visits a reference to a user-defined type.
+        /// </summary>
+        /// <param name="userType">The user type being referenced by a field.</param>
+        void VisitUserType(IUserType userType);
     }
 }

--- a/src/Thrift.Net.Compilation/Symbols/SymbolVisitor.cs
+++ b/src/Thrift.Net.Compilation/Symbols/SymbolVisitor.cs
@@ -39,5 +39,10 @@ namespace Thrift.Net.Compilation.Symbols
         public virtual void VisitListType(IListType listType)
         {
         }
+
+        /// <inheritdoc/>
+        public virtual void VisitUserType(IUserType userType)
+        {
+        }
     }
 }

--- a/src/Thrift.Net.Compilation/Symbols/UserType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/UserType.cs
@@ -78,6 +78,13 @@ namespace Thrift.Net.Compilation.Symbols
         /// <inheritdoc/>
         public bool IsList => false;
 
+        /// <inheritdoc/>
+        public override void Accept(ISymbolVisitor visitor)
+        {
+            visitor.VisitUserType(this);
+            base.Accept(visitor);
+        }
+
         private string GetOptionalTypeName()
         {
             return this.IsEnum ? this.Definition.Name + "?" : this.Definition.Name;

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructErrorTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructErrorTests.cs
@@ -99,5 +99,16 @@ CompilerMessageId.ListMustHaveElementTypeSpecified);
 }",
 CompilerMessageId.ListMustHaveElementTypeSpecified);
         }
+
+        [Fact]
+        public void Compile_ListElementUnresolved_ReportsError()
+        {
+            this.AssertCompilerReturnsErrorMessage(
+@"struct User {
+    1: list<$PermissionType$> Permissions
+}",
+CompilerMessageId.UnknownType,
+"PermissionType");
+        }
     }
 }


### PR DESCRIPTION
- Updated the compiler to output an error message if the list element type can't be resolved.
- To get this to work, I've updated the visitor to visit user types, and moved the error handling
  for unresolved types there from the `VisitField()` method.

Part of #11