### PR TITLE
fix(compiler): report error for field Id of `0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ currently working on implementing a Thrift compiler that is compatible with the
 Once we have a working compiler, the next step will be to implement the runtime
 library to make Thrift.Net self contained.
 
-For information about the initial design goals for the project, see the
-[design goals](docs/design-goals.md) page. For information on the project
-roadmap, see the [roadmap page](docs/roadmap.md).
+- For information about the initial design goals for the project, see the
+  [design goals](docs/design-goals.md) page.
+- For information on the project roadmap, see the
+  [roadmap page](docs/roadmap.md).
+- For information about the compiler design, see the
+  [compilation page](docs/compilation.md).
 
 ## Contributing
 

--- a/src/Thrift.Net.Compilation/Binding/FieldBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/FieldBinder.cs
@@ -61,7 +61,7 @@ namespace Thrift.Net.Compilation.Binding
             if (node.fieldId != null)
             {
                 if (int.TryParse(node.fieldId.Text, out var fieldId) &&
-                    fieldId >= 0)
+                    fieldId > 0)
                 {
                     return fieldId;
                 }

--- a/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
+++ b/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
@@ -122,7 +122,7 @@
     <value>Field Id '{0}' has already been used by another field in this struct.</value>
   </data>
   <data name="TC0203" xml:space="preserve">
-    <value>Field Id '{0}' is not valid. Field Ids must be positive integers.</value>
+    <value>Field Id '{0}' is not valid. Please use a positive number.</value>
   </data>
   <data name="TC0204" xml:space="preserve">
     <value>'{0}' uses the `slist` type, which should no-longer be used. Please use the `string` type instead.</value>

--- a/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/FieldIdTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/FieldBinder/FieldIdTests.cs
@@ -146,5 +146,21 @@ namespace Thrift.Net.Tests.Compilation.Binding.FieldBinder
             // Assert
             Assert.Null(field.FieldId);
         }
+
+        [Fact]
+        public void Bind_FieldIdZero_SetsFieldIdNull()
+        {
+            // Arrange
+            var @struct = new StructBuilder().Build();
+            var fieldContext = ParserInput
+                .FromString("0: i32 Id")
+                .ParseInput(parser => parser.field());
+
+            // Act
+            var field = this.binder.Bind<Field>(fieldContext, @struct);
+
+            // Assert
+            Assert.Null(field.FieldId);
+        }
     }
 }

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/CommentTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/CommentTests.cs
@@ -10,7 +10,7 @@ namespace Thrift.Net.Tests.Compilation.ThriftCompiler
             var input =
 @"// Represents a User
 struct User {
-    0: i32 Id
+    1: i32 Id
 }";
             this.AssertCompilerDoesNotReturnAnyMessages(input);
         }
@@ -21,7 +21,7 @@ struct User {
             var input =
 @"# Represents a User
 struct User {
-    0: i32 Id
+    1: i32 Id
 }";
             this.AssertCompilerDoesNotReturnAnyMessages(input);
         }
@@ -34,7 +34,7 @@ struct User {
  * Represents a user.
  */
 struct User {
-    0: i32 Id
+    1: i32 Id
 }";
             this.AssertCompilerDoesNotReturnAnyMessages(input);
         }

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructErrorTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/StructErrorTests.cs
@@ -70,6 +70,17 @@ CompilerMessageId.StructFieldIdMustBeAPositiveInteger,
         }
 
         [Fact]
+        public void Compile_FieldIdZero_ReportsError()
+        {
+            this.AssertCompilerReturnsErrorMessage(
+@"struct User {
+    $0$: string Username
+}",
+CompilerMessageId.StructFieldIdMustBeAPositiveInteger,
+"0");
+        }
+
+        [Fact]
         public void Compile_FieldTypeCannotBeResolved_ReportsError()
         {
             this.AssertCompilerReturnsErrorMessage(

--- a/src/Thrift.Net.Tests/Compilation/ThriftDocumentGenerator/StructGeneration/IsSetTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftDocumentGenerator/StructGeneration/IsSetTests.cs
@@ -1,6 +1,5 @@
 namespace Thrift.Net.Tests.Compilation.ThriftDocumentGenerator.StructGeneration
 {
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -8,8 +7,6 @@ namespace Thrift.Net.Tests.Compilation.ThriftDocumentGenerator.StructGeneration
     using Microsoft.CodeAnalysis.CSharp.Scripting;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Scripting;
-    using Thrift.Net.Compilation.Symbols;
-    using Thrift.Net.Compilation.Symbols.Builders;
     using Thrift.Net.Tests.Extensions;
     using Thrift.Protocol;
     using Xunit;
@@ -108,8 +105,8 @@ struct User {
             // Arrange
             var input =
 @"struct User {
-    0: bool Field1
-    1: bool Field2
+    1: bool Field1
+    2: bool Field2
 }";
             var compilationResult = this.Compiler.Compile(input.ToStream());
 
@@ -139,7 +136,7 @@ return user.IsSet.Field1 == false &&
             // Arrange
             var input =
 @"struct User {
-    0: bool Field1
+    1: bool Field1
 }";
             var compilationResult = this.Compiler.Compile(input.ToStream());
 
@@ -169,7 +166,7 @@ return user.IsSet.Field1;";
             // Arrange
             var input =
 @"struct User {
-    0: bool Field1
+    1: bool Field1
 }";
             var compilationResult = this.Compiler.Compile(input.ToStream());
 


### PR DESCRIPTION
- Fixed the compiler so that it reports an error if a field Id of `0` is specified. When I
  originally implemented the check, I got confused because the behaviour between field Ids and enum
  values is different.
- I reworded the error message so that it provides a suggestion for how to solve the problem rather
  than just stating what's wrong.
- Fixed any unit tests that were accidentally using a field Id of `0` in test cases.
- Added a section to the compilation page documenting the decision to report this as an error rather
  than a warning since it differs from the official compiler.
- Added a link to the compilation doc to the main README.

Fixes #62