### PR TITLE
feat(compiler): generate Equals and GetHashCode

### DIFF
--- a/src/Thrift.Net.Compilation/Symbols/BaseType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/BaseType.cs
@@ -127,6 +127,9 @@ namespace Thrift.Net.Compilation.Symbols
         /// <inheritdoc/>
         public bool IsList => false;
 
+        /// <inheritdoc/>
+        public bool IsCollection => false;
+
         /// <summary>
         /// Resolves the specified node into a base type.
         /// </summary>

--- a/src/Thrift.Net.Compilation/Symbols/CollectionType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/CollectionType.cs
@@ -101,6 +101,9 @@ namespace Thrift.Net.Compilation.Symbols
         public abstract bool IsList { get; }
 
         /// <inheritdoc/>
+        public bool IsCollection => true;
+
+        /// <inheritdoc/>
         protected override IReadOnlyCollection<ISymbol> Children =>
             this.ElementType != null ? new List<ISymbol> { this.ElementType } : new List<ISymbol>();
 

--- a/src/Thrift.Net.Compilation/Symbols/IFieldType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/IFieldType.cs
@@ -45,5 +45,10 @@ namespace Thrift.Net.Compilation.Symbols
         /// Gets a value indicating whether the type is a list.
         /// </summary>
         public bool IsList { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the type is a collection.
+        /// </summary>
+        public bool IsCollection { get; }
     }
 }

--- a/src/Thrift.Net.Compilation/Symbols/UserType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/UserType.cs
@@ -79,6 +79,9 @@ namespace Thrift.Net.Compilation.Symbols
         public bool IsList => false;
 
         /// <inheritdoc/>
+        public bool IsCollection => false;
+
+        /// <inheritdoc/>
         public override void Accept(ISymbolVisitor visitor)
         {
             visitor.VisitUserType(this);

--- a/src/Thrift.Net.Compilation/Templates/csharp.stg
+++ b/src/Thrift.Net.Compilation/Templates/csharp.stg
@@ -14,9 +14,11 @@ $endif$
 >>
 
 generateDocument(model, typeMap) ::= <<
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Thrift.Collections;
 using Thrift.Protocol;
 using Thrift.Protocol.Entities;
 using Thrift.Protocol.Utilities;
@@ -44,6 +46,7 @@ $member.Name$ = $member.Value$
 generateStruct(struct, typeMap) ::= <<
 public class $struct.Name$ : TBase
 {
+$if(struct.Fields)$
 $if(struct.OptionalFields)$
     private IsSetInfo isSet;
 $endif$
@@ -61,6 +64,7 @@ $if(struct.OptionalFields)$
 $endif$
     $struct.Fields:generateField(); separator="\n\n"$
 
+$endif$
     /// <inheritdoc />
     public async Task ReadAsync(TProtocol protocol, CancellationToken cancellationToken)
     {
@@ -80,8 +84,10 @@ $endif$
 
                 switch (field.ID)
                 {
+$if(struct.Fields)$
                     $struct.Fields:{field | $generateReadFieldCaseStatement(field, typeMap)$}; separator="\n\n"$
 
+$endif$
                     default: 
                         await TProtocolUtil.SkipAsync(protocol, field.Type, cancellationToken);
 
@@ -108,11 +114,12 @@ $endif$
         {
             var @struct = new TStruct("$struct.Name$");
             await protocol.WriteStructBeginAsync(@struct, cancellationToken);
-
+$if(struct.Fields)$
             var field = new TField();
 
             $struct.Fields:{field | $generateWriteField(field, typeMap)$}; separator="\n\n"$
-      
+
+$endif$      
             await protocol.WriteFieldStopAsync(cancellationToken);
             await protocol.WriteStructEndAsync(cancellationToken);
         }
@@ -120,6 +127,33 @@ $endif$
         {
             protocol.DecrementRecursionDepth();
         }
+    }
+$if(struct.Fields)$
+
+    /// <inheritdoc />
+    public override bool Equals(object obj)
+    {
+        return obj is $struct.Name$ other && this.Equals(other);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hashCode = new HashCode();
+        $struct.Fields:{f | hashCode.Add(this.$f.Name$);}; separator="\n"$
+
+        return hashCode.ToHashCode();
+    }
+
+    private bool Equals($struct.Name$ other)
+    {
+        if (object.ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return other != null &&
+            $struct.Fields:generateEqualsComparison(); separator=" &&\n"$;
     }
 
     /// <summary>
@@ -130,6 +164,7 @@ $endif$
     {
         $struct.Fields:generateFieldId(); separator="\n\n"$
     }
+$endif$
 $if(struct.OptionalFields)$
 
     /// <summary>
@@ -339,4 +374,12 @@ $name$$nestingDepth$
 
 qualifyWithThis(name) ::= <%
 this.$name$
+%>
+
+generateEqualsComparison(field) ::= <%
+$if(field.Type.IsCollection)$
+    TCollections.Equals(this.$field.Name$, other.$field.Name$)
+$else$
+    object.Equals(this.$field.Name$, other.$field.Name$)
+$endif$
 %>

--- a/thrift-samples/structs/User.thrift
+++ b/thrift-samples/structs/User.thrift
@@ -1,7 +1,7 @@
 namespace netstd Thrift.Net.Examples
 
 enum UserType {
-    User = 1
+    User = 0
     Administrator = 2
 }
 
@@ -13,17 +13,22 @@ struct Address {
     5: string Country
 }
 
+enum PermissionType {
+    Read = 0
+    Write = 1
+    Execute = 2
+}
+
+struct Permission {
+    1: PermissionType Type
+    2: string Name
+}
+
 struct User {
     1: i32 Id
     2: required UserType Type
-    3: Address Address
-    4: PermissionType PermissionType
+    3: list<Address> Addresses
+    4: set<Permission> Permissions
     5: UserType SecondaryType
-    // 5: Unknown Unknown
-}
-
-enum PermissionType {
-    Read
-    Write
-    Execute
+    6: set<string> Emails
 }


### PR DESCRIPTION
- Updated the template to override the `Equals()` and `GetHashCode()` methods for structs.
- The implementation differs slightly from the official compiler because I haven't bothered checking
  the `IsSet` properties and just compared the actual field values themselves. I did this on the
  grounds that they should always be in sync, but we can always change that later if it turns out to
  be required.
- I've used the `System.HashCode` object to generate the hashcodes. It's available from .NET
  Standard 2.1. We might need to revisit if we decide to support older framework versions, but I
  figured there was no harm in using it until that point.
- Updated the User.thrift example to get it to use lists and sets.
- Tweaked the template to improve the formatting of the generated code when structs are empty.

Part of #59