### PR TITLE
ci: stop pinning code coverage version

### DIFF
--- a/pipelines/build-and-run-tests.yaml
+++ b/pipelines/build-and-run-tests.yaml
@@ -26,7 +26,7 @@ steps:
     projects: '$(System.DefaultWorkingDirectory)/src/Thrift.Net.Tests/Thrift.Net.Tests.csproj'
     arguments: '--configuration Release -warnaserror /p:PublishSingleFile=false --collect "XPlat Code Coverage" --settings "$(System.DefaultWorkingDirectory)/src/Thrift.Net.Tests/Thrift.Net.Tests.runsettings"'
 
-- task: PublishCodeCoverageResults@1.175.0
+- task: PublishCodeCoverageResults@1
   displayName: 'Publish Code Coverage'
   inputs:
     codeCoverageTool: 'cobertura'


### PR DESCRIPTION
A fix has been pushed for the task now so we shouldn't need to pin the version anymore.

Part of #80
