### PR TITLE
fix: solve LGTM alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Thrift.Net
 
 [![Build Status](https://dev.azure.com/adamrpconnelly/Thrift.Net/_apis/build/status/Build%20and%20Run%20Tests?branchName=main)](https://dev.azure.com/adamrpconnelly/Thrift.Net/_build/latest?definitionId=3&branchName=main)
+![Azure DevOps tests](https://img.shields.io/azure-devops/tests/adamrpconnelly/Thrift.Net/3)
+![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/adamrpconnelly/Thrift.Net/3)
+
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/adamconnelly/Thrift.Net.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adamconnelly/Thrift.Net/alerts/)
+[![Language grade: C#](https://img.shields.io/lgtm/grade/csharp/g/adamconnelly/Thrift.Net.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adamconnelly/Thrift.Net/context:csharp)
 
 The aim of the Thrift.Net project is to create an implementation of the
 [Thrift](https://thrift.apache.org/) compiler and runtime library in C#,

--- a/src/Thrift.Net.Compilation/Symbols/Document.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Document.cs
@@ -125,9 +125,8 @@ namespace Thrift.Net.Compilation.Symbols
         /// <inheritdoc/>
         public bool IsMemberNameAlreadyDeclared(INamedSymbol member)
         {
-            var parent = member.Node.Parent as DefinitionsContext;
-
-            if (parent.children.Count <= 1)
+            if (member.Node.Parent is DefinitionsContext parent &&
+                parent.children.Count <= 1)
             {
                 return false;
             }

--- a/src/Thrift.Net.Compiler/Program.cs
+++ b/src/Thrift.Net.Compiler/Program.cs
@@ -56,7 +56,7 @@
         /// The exit code. This can be used by scripts to determine whether the
         /// compile was successful or not.
         /// </returns>
-        public static int Main(FileInfo input, DirectoryInfo outputDirectory, IConsole console = null)
+        public static int Main(FileInfo input, DirectoryInfo outputDirectory, IConsole console)
         {
             if (!input.Exists)
             {

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ThriftCompilerTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ThriftCompilerTests.cs
@@ -26,18 +26,24 @@ namespace Thrift.Net.Tests.Compilation.ThriftCompiler
                 m => m.MessageType == messageType && m.MessageId == messageId);
             Assert.True(message != null, $"No {messageType.ToString().ToLower()} messages were returned from the compiler");
 
-            if (parserInput.LineNumber != null)
+            // Although we know that message cannot be null because of the assert on
+            // the previous line, check for null here because the lgtm check isn't
+            // smart enough to realise that
+            if (message != null)
             {
-                Assert.Equal(parserInput.LineNumber, message.LineNumber);
-                Assert.Equal(parserInput.StartPosition, message.StartPosition);
-                Assert.Equal(parserInput.EndPosition, message.EndPosition);
-            }
+                if (parserInput.LineNumber != null)
+                {
+                    Assert.Equal(parserInput.LineNumber, message.LineNumber);
+                    Assert.Equal(parserInput.StartPosition, message.StartPosition);
+                    Assert.Equal(parserInput.EndPosition, message.EndPosition);
+                }
 
-            if (messageParameters?.Length > 0)
-            {
-                var expectedMessage = string.Format(
-                    CompilerMessages.Get(messageId), messageParameters);
-                Assert.Equal(expectedMessage, message.Message);
+                if (messageParameters?.Length > 0)
+                {
+                    var expectedMessage = string.Format(
+                        CompilerMessages.Get(messageId), messageParameters);
+                    Assert.Equal(expectedMessage, message.Message);
+                }
             }
         }
 

--- a/src/Thrift.Net.Tests/Utility/ParserInput.cs
+++ b/src/Thrift.Net.Tests/Utility/ParserInput.cs
@@ -62,7 +62,7 @@ namespace Thrift.Net.Tests.Utility
             int? lineNumber = null;
             int? startPosition = null;
             int? endPosition = null;
-            var reader = new StringReader(input);
+            using var reader = new StringReader(input);
 
             if (input.Contains('$'))
             {


### PR DESCRIPTION
- Fixed a potential NullReferenceException in `Document.IsMemberNameAlreadyDeclared()`.
- Removed the default value from the `console` parameter in the compiler's `Main()` method. I think
  this is why LGTM thinks that console can be null whereas in reality is can't be.
- Added a null check to the ThriftCompilerTests. Like the previous fix, the `message` variable can't
  really be null because of the assert on the previous line, but I've just decided to add the check
  anyway to remove the warning.
- Fixed a problem where the `ParserInput` class wasn't properly disposing of its `StringReader`.
  This was a legitimate issue, although it only affected the tests.

Part of #83
