### PR TITLE
fix(compiler): verify required fields are set

### DIFF
--- a/src/Thrift.Net.Compilation/Symbols/IFieldContainer.cs
+++ b/src/Thrift.Net.Compilation/Symbols/IFieldContainer.cs
@@ -16,5 +16,10 @@ namespace Thrift.Net.Compilation.Symbols
         /// Gets the fields that are optional (either explicitly or implicitly).
         /// </summary>
         IReadOnlyCollection<Field> OptionalFields { get; }
+
+        /// <summary>
+        /// Gets the fields that are required.
+        /// </summary>
+        IReadOnlyCollection<Field> RequiredFields { get; }
     }
 }

--- a/src/Thrift.Net.Compilation/Symbols/Struct.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Struct.cs
@@ -48,6 +48,11 @@ namespace Thrift.Net.Compilation.Symbols
             .ToList();
 
         /// <inheritdoc/>
+        public IReadOnlyCollection<Field> RequiredFields => this.Fields
+            .Where(field => field.Requiredness == FieldRequiredness.Required)
+            .ToList();
+
+        /// <inheritdoc/>
         public IDocument Document => this.Parent;
 
         /// <inheritdoc />

--- a/src/Thrift.Net.Compilation/Symbols/Union.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Union.cs
@@ -52,6 +52,11 @@ namespace Thrift.Net.Compilation.Symbols
                 .ToList();
 
         /// <inheritdoc/>
+        public IReadOnlyCollection<Field> RequiredFields => this.Fields
+            .Where(field => field.Requiredness == FieldRequiredness.Required)
+            .ToList();
+
+        /// <inheritdoc/>
         protected override IReadOnlyCollection<ISymbol> Children => this.Fields;
 
         /// <inheritdoc/>

--- a/src/Thrift.Net.Compilation/Templates/csharp.stg
+++ b/src/Thrift.Net.Compilation/Templates/csharp.stg
@@ -76,6 +76,10 @@ $endif$
 
         try
         {
+            $if(struct.RequiredFields)$
+            $struct.RequiredFields:declareIsSetVariable(); separator="\n"$
+
+            $endif$
             await protocol.ReadStructBeginAsync(cancellationToken);
         
             while (true)
@@ -102,6 +106,10 @@ $endif$
             }
 
             await protocol.ReadStructEndAsync(cancellationToken);
+            $if(struct.RequiredFields)$
+
+            $struct.RequiredFields:verifyRequiredFieldIsSet(); separator="\n\n"$
+            $endif$
         }
         finally
         {
@@ -183,6 +191,17 @@ $endif$
 }
 >>
 
+declareIsSetVariable(field) ::= <<
+var isSet_$field.Name$ = false;
+>>
+
+verifyRequiredFieldIsSet(field) ::= <<
+if (!isSet_$field.Name$)
+{
+    throw new TProtocolException(TProtocolException.INVALID_DATA);
+}
+>>
+
 backingFieldName(field) ::= <<
 _$field.Name$
 >>
@@ -230,6 +249,9 @@ case FieldIds.$field.Name$:
     if (field.Type == $getTType(field.Type, typeMap)$)
     {
         $generateReadMethod(qualifyWithThis(field.Name), field.Type, typeMap, false)$
+        $if(field.IsRequired)$
+        isSet_$field.Name$ = true;
+        $endif$
     }
     else
     {


### PR DESCRIPTION
- I've updated the compiler to generate code in the `ReadAsync()` methods of structs and unions
  that tracks whether each required field has been set, and throws a `TProtocolException` if any
  required fields are not set.

Fixes #85
