### PR TITLE
chore: add sln file for dependabot

### DIFF
--- a/.vscode/solution-explorer/class.cs-template
+++ b/.vscode/solution-explorer/class.cs-template
@@ -1,0 +1,6 @@
+namespace {{namespace}}
+{
+    public class {{name}}
+    {
+    }
+}

--- a/.vscode/solution-explorer/class.ts-template
+++ b/.vscode/solution-explorer/class.ts-template
@@ -1,0 +1,3 @@
+export class {{name}} {
+
+}

--- a/.vscode/solution-explorer/class.vb-template
+++ b/.vscode/solution-explorer/class.vb-template
@@ -1,0 +1,9 @@
+Imports System
+
+Namespace {{namespace}}
+
+    Public Class {{name}}
+    
+    End Class
+
+End Namespace

--- a/.vscode/solution-explorer/default.ts-template
+++ b/.vscode/solution-explorer/default.ts-template
@@ -1,0 +1,3 @@
+export default {{name}} {
+
+}

--- a/.vscode/solution-explorer/enum.cs-template
+++ b/.vscode/solution-explorer/enum.cs-template
@@ -1,0 +1,6 @@
+namespace {{namespace}}
+{
+    public enum {{name}}
+    {
+    }
+}

--- a/.vscode/solution-explorer/interface.cs-template
+++ b/.vscode/solution-explorer/interface.cs-template
@@ -1,0 +1,6 @@
+namespace {{namespace}}
+{
+    public interface {{name}}
+    {
+    }
+}

--- a/.vscode/solution-explorer/interface.ts-template
+++ b/.vscode/solution-explorer/interface.ts-template
@@ -1,0 +1,3 @@
+export interface {{name}} {
+
+}

--- a/.vscode/solution-explorer/template-list.json
+++ b/.vscode/solution-explorer/template-list.json
@@ -1,0 +1,46 @@
+{
+    "templates": [
+        {
+            "name": "Class",
+            "extension": "cs",
+            "file": "./class.cs-template",
+            "parameters": "./template-parameters.js"
+        },
+        {
+            "name": "Interface",
+            "extension": "cs",
+            "file": "./interface.cs-template",
+            "parameters": "./template-parameters.js"
+        },
+        {
+            "name": "Enum",
+            "extension": "cs",
+            "file": "./enum.cs-template",
+            "parameters": "./template-parameters.js"
+        },
+        {
+            "name": "Class",
+            "extension": "ts",
+            "file": "./class.ts-template",
+            "parameters": "./template-parameters.js"
+        },
+        {
+            "name": "Interface",
+            "extension": "ts",
+            "file": "./interface.ts-template",
+            "parameters": "./template-parameters.js"
+        },
+        {
+            "name": "Default",
+            "extension": "ts",
+            "file": "./default.ts-template",
+            "parameters": "./template-parameters.js"
+        },
+        {
+            "name": "Class",
+            "extension": "vb",
+            "file": "./class.vb-template",
+            "parameters": "./template-parameters.js"
+        }
+    ]
+}

--- a/.vscode/solution-explorer/template-parameters.js
+++ b/.vscode/solution-explorer/template-parameters.js
@@ -1,0 +1,22 @@
+var path = require("path");
+
+module.exports = function (filename, projectPath, folderPath) {
+  var namespace = "Unknown";
+  if (projectPath) {
+    namespace = path.basename(projectPath, path.extname(projectPath));
+    if (folderPath) {
+      namespace +=
+        "." +
+        folderPath
+          .replace(path.dirname(projectPath), "")
+          .substring(1)
+          .replace(/[\\\/]/g, ".");
+    }
+    namespace = namespace.replace(/[\\\-]/g, "_");
+  }
+
+  return {
+    namespace: namespace,
+    name: path.basename(filename, path.extname(filename)),
+  };
+};

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/src/Thrift.Net.Tests/Thrift.Net.Tests.csproj",
+                "${workspaceFolder}/src/Thrift.Net.sln",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -19,7 +19,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/src/Thrift.Net.Tests/Thrift.Net.Tests.csproj",
+                "${workspaceFolder}/src/Thrift.Net.sln",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -33,79 +33,6 @@
                 "watch",
                 "run",
                 "${workspaceFolder}/src/Thrift.Net.Tests/Thrift.Net.Tests.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "build Thrift.Net.Antlr",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/src/Thrift.Net.Antlr/Thrift.Net.Antlr.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "build Thrift.Net.Compilation",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/src/Thrift.Net.Compilation/Thrift.Net.Compilation.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "build Thrift.Net.Compiler",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/src/Thrift.Net.Compiler/Thrift.Net.Compiler.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "build Thrift.Net.Tests",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/src/Thrift.Net.Tests/Thrift.Net.Tests.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "publish",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "publish",
-                "${workspaceFolder}/src/Thrift.Net.Compilation/Thrift.Net.Compilation.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "watch",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "watch",
-                "run",
-                "${workspaceFolder}/src/Thrift.Net.Compilation/Thrift.Net.Compilation.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],

--- a/commitlint-ci.config.js
+++ b/commitlint-ci.config.js
@@ -1,4 +1,9 @@
 module.exports = {
   extends: ["./commitlint.config.js"],
   defaultIgnores: false, // Don't allow things like `fixup!` when running against PRs
+  ignores: [
+    // Don't lint Dependabot commit messages because it doesn't reference an issue
+    // and will fail linting
+    (commit) => commit.startsWith("chore(deps"),
+  ],
 };

--- a/src/Thrift.Net.sln
+++ b/src/Thrift.Net.sln
@@ -1,0 +1,76 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thrift.Net.Antlr", "Thrift.Net.Antlr\Thrift.Net.Antlr.csproj", "{31222915-E15E-4A21-A4AE-EEAA03935C1E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thrift.Net.Compilation", "Thrift.Net.Compilation\Thrift.Net.Compilation.csproj", "{408EBC5D-6510-4ACE-A0F4-307EA8B62803}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thrift.Net.Compiler", "Thrift.Net.Compiler\Thrift.Net.Compiler.csproj", "{453A4C0E-7162-4EC9-852E-D926B1532894}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thrift.Net.Tests", "Thrift.Net.Tests\Thrift.Net.Tests.csproj", "{8D7BC817-BD07-4C37-B453-EDEA9B217355}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Debug|x64.Build.0 = Debug|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Debug|x86.Build.0 = Debug|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Release|x64.ActiveCfg = Release|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Release|x64.Build.0 = Release|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Release|x86.ActiveCfg = Release|Any CPU
+		{31222915-E15E-4A21-A4AE-EEAA03935C1E}.Release|x86.Build.0 = Release|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Debug|x64.Build.0 = Debug|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Debug|x86.Build.0 = Debug|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Release|Any CPU.Build.0 = Release|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Release|x64.ActiveCfg = Release|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Release|x64.Build.0 = Release|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Release|x86.ActiveCfg = Release|Any CPU
+		{408EBC5D-6510-4ACE-A0F4-307EA8B62803}.Release|x86.Build.0 = Release|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Debug|x64.Build.0 = Debug|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Debug|x86.Build.0 = Debug|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Release|Any CPU.Build.0 = Release|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Release|x64.ActiveCfg = Release|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Release|x64.Build.0 = Release|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Release|x86.ActiveCfg = Release|Any CPU
+		{453A4C0E-7162-4EC9-852E-D926B1532894}.Release|x86.Build.0 = Release|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Debug|x64.Build.0 = Debug|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Debug|x86.Build.0 = Debug|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Release|x64.ActiveCfg = Release|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Release|x64.Build.0 = Release|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Release|x86.ActiveCfg = Release|Any CPU
+		{8D7BC817-BD07-4C37-B453-EDEA9B217355}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- Added a sln file because dependabot doesn't support a wildcard pattern to find csproj files.
- Added template files for the vscode sln explorer extension.
- Adjusted the vscode tasks to just allow building the sln file instead of having a build task for
  each project. I figure this is less work to update.

Part of #87
