### PR TITLE
feat(compiler): add exception support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .antlr
 thrift-output/
 artifacts/
+TODO

--- a/src/Thrift.Net.Antlr/Thrift.g4
+++ b/src/Thrift.Net.Antlr/Thrift.g4
@@ -26,7 +26,11 @@ namespaceStatement: (
                                  // but allowing it lets us handle the situation
                                  // where someone has added a separator by accident
 
-definitions: (enumDefinition | structDefinition | unionDefinition)*;
+definitions: (
+    enumDefinition |
+    structDefinition |
+    unionDefinition |
+    exceptionDefinition)*;
 
 enumDefinition: ENUM name=IDENTIFIER?
     '{'
@@ -45,6 +49,11 @@ structDefinition: STRUCT name=IDENTIFIER?
     '}';
 
 unionDefinition: UNION name=IDENTIFIER?
+    '{'
+        field*
+    '}';
+
+exceptionDefinition: EXCEPTION name=IDENTIFIER?
     '{'
         field*
     '}';
@@ -69,6 +78,7 @@ NAMESPACE: 'namespace';
 ENUM: 'enum';
 STRUCT: 'struct';
 UNION: 'union';
+EXCEPTION: 'exception';
 REQUIRED: 'required';
 OPTIONAL: 'optional';
 LIST: 'list';

--- a/src/Thrift.Net.Compilation/Binding/BinderProvider.cs
+++ b/src/Thrift.Net.Compilation/Binding/BinderProvider.cs
@@ -15,6 +15,7 @@ namespace Thrift.Net.Compilation.Binding
         private static readonly NamespaceBinder NamespaceBinder;
         private static readonly StructBinder StructBinder;
         private static readonly UnionBinder UnionBinder;
+        private static readonly ExceptionBinder ExceptionBinder;
         private static readonly EnumBinder EnumBinder;
         private static readonly EnumMemberBinder EnumMemberBinder;
         private static readonly FieldBinder FieldBinder;
@@ -33,6 +34,7 @@ namespace Thrift.Net.Compilation.Binding
             NamespaceBinder = new NamespaceBinder(ProviderInstance);
             StructBinder = new StructBinder(ProviderInstance);
             UnionBinder = new UnionBinder(ProviderInstance);
+            ExceptionBinder = new ExceptionBinder(ProviderInstance);
             EnumBinder = new EnumBinder(ProviderInstance);
             EnumMemberBinder = new EnumMemberBinder(ProviderInstance);
             FieldBinder = new FieldBinder(ProviderInstance);
@@ -121,6 +123,10 @@ namespace Thrift.Net.Compilation.Binding
             else if (node is MapTypeContext)
             {
                 return MapTypeBinder;
+            }
+            else if (node is ExceptionDefinitionContext)
+            {
+                return ExceptionBinder;
             }
 
             throw new ArgumentException(

--- a/src/Thrift.Net.Compilation/Binding/ExceptionBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/ExceptionBinder.cs
@@ -1,0 +1,37 @@
+namespace Thrift.Net.Compilation.Binding
+{
+    using Thrift.Net.Compilation.Symbols;
+    using Thrift.Net.Compilation.Symbols.Builders;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Used to bind a <see cref="Struct" /> from the parse tree.
+    /// </summary>
+    public class ExceptionBinder : Binder<ExceptionDefinitionContext, Exception, IDocument>
+    {
+        private readonly IBinderProvider binderProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionBinder" /> class.
+        /// </summary>
+        /// <param name="binderProvider">
+        /// Used to get the correct binder for a particular node.
+        /// </param>
+        public ExceptionBinder(IBinderProvider binderProvider)
+        {
+            this.binderProvider = binderProvider;
+        }
+
+        /// <inheritdoc />
+        protected override Exception Bind(ExceptionDefinitionContext node, IDocument parent)
+        {
+            var builder = new ExceptionBuilder()
+                .SetNode(node)
+                .SetParent(parent)
+                .SetBinderProvider(this.binderProvider)
+                .SetName(node.name?.Text);
+
+            return builder.Build();
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Binding/FieldBinder.cs
+++ b/src/Thrift.Net.Compilation/Binding/FieldBinder.cs
@@ -81,6 +81,14 @@ namespace Thrift.Net.Compilation.Binding
                     .IndexOf(node) + 1) * -1;
             }
 
+            if (node.Parent is ExceptionDefinitionContext exceptionNode)
+            {
+                return (exceptionNode.field()
+                    .Where(field => field.fieldId == null)
+                    .ToList()
+                    .IndexOf(node) + 1) * -1;
+            }
+
             return -1;
         }
     }

--- a/src/Thrift.Net.Compilation/CompilationVisitor.cs
+++ b/src/Thrift.Net.Compilation/CompilationVisitor.cs
@@ -379,6 +379,33 @@ namespace Thrift.Net.Compilation
             base.VisitUnion(union);
         }
 
+        /// <inheritdoc/>
+        public override void VisitException(IException exception)
+        {
+            if (exception.Name == null)
+            {
+                // An exception has been declared with no name. For example `exception {}`.
+                this.AddError(
+                    CompilerMessageId.ExceptionMustHaveAName,
+                    exception.Node.EXCEPTION().Symbol);
+            }
+            else if (exception.Parent.IsMemberNameAlreadyDeclared(exception))
+            {
+                // Another type has already been declared with the same name.
+                // For example:
+                // ```
+                // struct Request {}
+                // exception Request {}
+                // ```
+                this.AddError(
+                    CompilerMessageId.NameAlreadyDeclared,
+                    exception.Node.name,
+                    exception.Name);
+            }
+
+            base.VisitException(exception);
+        }
+
         private void AddEnumMessages(IEnum enumDefinition)
         {
             if (enumDefinition.Name == null)

--- a/src/Thrift.Net.Compilation/CompilerMessageId.cs
+++ b/src/Thrift.Net.Compilation/CompilerMessageId.cs
@@ -751,5 +751,25 @@ namespace Thrift.Net.Compilation
         /// </code>
         /// </example>
         UnionMustHaveAName = 601,
+
+        /// <summary>
+        /// An exception has been declared with no name.
+        /// </summary>
+        /// <example>
+        /// The following example produces this error:
+        /// <code>
+        /// exception {
+        ///   1: string Id
+        /// }
+        /// </code>
+        ///
+        /// To resolve this issue, add a name to the exception:
+        /// <code>
+        /// exception NotFoundException {
+        ///   1: string Id
+        /// }
+        /// </code>
+        /// </example>
+        ExceptionMustHaveAName = 700,
     }
 }

--- a/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
+++ b/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
@@ -161,4 +161,7 @@
   <data name="TC0601" xml:space="preserve">
     <value>A union name must be specified.</value>
   </data>
+  <data name="TC0700" xml:space="preserve">
+    <value>An exception name must be specified.</value>
+  </data>
 </root>

--- a/src/Thrift.Net.Compilation/Symbols/Builders/ExceptionBuilder.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Builders/ExceptionBuilder.cs
@@ -1,0 +1,33 @@
+namespace Thrift.Net.Compilation.Symbols.Builders
+{
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Used to build <see cref="Exception" /> symbols.
+    /// </summary>
+    public class ExceptionBuilder : SymbolBuilder<ExceptionDefinitionContext, Exception, IDocument, ExceptionBuilder>
+    {
+        /// <summary>
+        /// Gets the name of the exception.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Sets the name of the exception.
+        /// </summary>
+        /// <param name="name">The name of the exception.</param>
+        /// <returns>The builder.</returns>
+        public ExceptionBuilder SetName(string name)
+        {
+            this.Name = name;
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public override Exception Build()
+        {
+            return new Exception(this.Node, this.BinderProvider, this.Parent, this.Name);
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Symbols/Document.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Document.cs
@@ -77,6 +77,19 @@ namespace Thrift.Net.Compilation.Symbols
         }
 
         /// <inheritdoc/>
+        public IReadOnlyCollection<IException> Exceptions
+        {
+            get
+            {
+                return this.Node.definitions().exceptionDefinition()
+                    .Select(exceptionNode => this.binderProvider
+                        .GetBinder(exceptionNode)
+                        .Bind<IException>(exceptionNode, this))
+                    .ToList();
+            }
+        }
+
+        /// <inheritdoc/>
         public IReadOnlyCollection<INamedTypeSymbol> AllTypes
         {
             get
@@ -84,6 +97,7 @@ namespace Thrift.Net.Compilation.Symbols
                 return this.Enums.Cast<INamedTypeSymbol>()
                     .Union(this.Structs)
                     .Union(this.Unions)
+                    .Union(this.Exceptions)
                     .OrderBy(symbol => symbol.Node.SourceInterval.a)
                     .ToList();
             }
@@ -115,9 +129,7 @@ namespace Thrift.Net.Compilation.Symbols
             get
             {
                 return this.Namespaces.Cast<ISymbol>()
-                    .Union(this.Structs)
-                    .Union(this.Unions)
-                    .Union(this.Enums)
+                    .Union(this.AllTypes)
                     .ToList();
             }
         }

--- a/src/Thrift.Net.Compilation/Symbols/Exception.cs
+++ b/src/Thrift.Net.Compilation/Symbols/Exception.cs
@@ -1,0 +1,68 @@
+namespace Thrift.Net.Compilation.Symbols
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Thrift.Net.Compilation.Binding;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Represents a Thrift Exception.
+    /// </summary>
+    public class Exception : NamedSymbol<ExceptionDefinitionContext, IDocument>, IException
+    {
+        private readonly IBinderProvider binderProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Exception" /> class.
+        /// </summary>
+        /// <param name="node">The union parse tree node.</param>
+        /// <param name="binderProvider">Used to get binders.</param>
+        /// <param name="parent">The document that contains this union.</param>
+        /// <param name="name">The name of the union.</param>
+        public Exception(
+            ExceptionDefinitionContext node,
+            IBinderProvider binderProvider,
+            IDocument parent,
+            string name)
+            : base(node, parent, name)
+        {
+            this.binderProvider = binderProvider;
+        }
+
+        /// <inheritdoc/>
+        public IDocument Document => this.Parent as IDocument;
+
+        /// <inheritdoc/>
+        public IReadOnlyCollection<Field> Fields
+        {
+            get
+            {
+                return this.Node.field()
+                    .Select(fieldNode => this.binderProvider
+                        .GetBinder(fieldNode)
+                        .Bind<Field>(fieldNode, this))
+                    .ToList();
+            }
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyCollection<Field> OptionalFields => this.Fields
+            .Where(field => field.Requiredness != FieldRequiredness.Required)
+            .ToList();
+
+        /// <inheritdoc/>
+        public IReadOnlyCollection<Field> RequiredFields => this.Fields
+            .Where(field => field.Requiredness == FieldRequiredness.Required)
+            .ToList();
+
+        /// <inheritdoc/>
+        protected override IReadOnlyCollection<ISymbol> Children => this.Fields;
+
+        /// <inheritdoc/>
+        public override void Accept(ISymbolVisitor visitor)
+        {
+            visitor.VisitException(this);
+            base.Accept(visitor);
+        }
+    }
+}

--- a/src/Thrift.Net.Compilation/Symbols/IDocument.cs
+++ b/src/Thrift.Net.Compilation/Symbols/IDocument.cs
@@ -29,6 +29,11 @@ namespace Thrift.Net.Compilation.Symbols
         IReadOnlyCollection<IUnion> Unions { get; }
 
         /// <summary>
+        /// Gets any exceptions that have been defined.
+        /// </summary>
+        IReadOnlyCollection<IException> Exceptions { get; }
+
+        /// <summary>
         /// Gets all the types contained by this document, in the order they
         /// appeared in the source.
         /// </summary>

--- a/src/Thrift.Net.Compilation/Symbols/IException.cs
+++ b/src/Thrift.Net.Compilation/Symbols/IException.cs
@@ -1,0 +1,11 @@
+namespace Thrift.Net.Compilation.Symbols
+{
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    /// <summary>
+    /// Represents a Thrift exception.
+    /// </summary>
+    public interface IException : ISymbol<ExceptionDefinitionContext, IDocument>, INamedTypeSymbol, IFieldContainer
+    {
+    }
+}

--- a/src/Thrift.Net.Compilation/Symbols/ISymbolVisitor.cs
+++ b/src/Thrift.Net.Compilation/Symbols/ISymbolVisitor.cs
@@ -70,5 +70,11 @@ namespace Thrift.Net.Compilation.Symbols
         /// </summary>
         /// <param name="union">The union to visit.</param>
         void VisitUnion(IUnion union);
+
+        /// <summary>
+        /// Visits an exception.
+        /// </summary>
+        /// <param name="exception">The exception to visit.</param>
+        void VisitException(IException exception);
     }
 }

--- a/src/Thrift.Net.Compilation/Symbols/SymbolVisitor.cs
+++ b/src/Thrift.Net.Compilation/Symbols/SymbolVisitor.cs
@@ -59,5 +59,10 @@ namespace Thrift.Net.Compilation.Symbols
         public virtual void VisitUnion(IUnion union)
         {
         }
+
+        /// <inheritdoc/>
+        public virtual void VisitException(IException exception)
+        {
+        }
     }
 }

--- a/src/Thrift.Net.Compilation/Templates/csharp.stg
+++ b/src/Thrift.Net.Compilation/Templates/csharp.stg
@@ -28,11 +28,15 @@ $model.Enums:generateEnum(); separator="\n\n"$
 $endif$
 $if(model.Structs)$
 
-$model.Structs:{struct | $generateMessage(struct, typeMap)$}; separator="\n\n"$
+$model.Structs:{struct | $generateMessage(struct, typeMap, false)$}; separator="\n\n"$
 $endif$
 $if(model.Unions)$
 
-$model.Unions:{union | $generateMessage(union, typeMap)$}; separator="\n\n"$
+$model.Unions:{union | $generateMessage(union, typeMap, false)$}; separator="\n\n"$
+$endif$
+$if(model.Exceptions)$
+
+$model.Exceptions:{exception | $generateMessage(exception, typeMap, true)$}; separator="\n\n"$
 $endif$
 >>
 
@@ -47,16 +51,20 @@ generateEnumMember(member) ::= <<
 $member.Name$ = $member.Value$
 >>
 
-generateMessage(struct, typeMap) ::= <<
-public class $struct.Name$ : TBase
+generateMessage(message, typeMap, isException) ::= <<
+$if(isException)$
+public class $message.Name$ : TException, TBase
+$else$
+public class $message.Name$ : TBase
+$endif$
 {
-$if(struct.Fields)$
-$if(struct.OptionalFields)$
+$if(message.Fields)$
+$if(message.OptionalFields)$
     private IsSetInfo isSet;
 $endif$
-    $struct.Fields:generateBackingField(); separator="\n"$
+    $message.Fields:generateBackingField(); separator="\n"$
 
-$if(struct.OptionalFields)$
+$if(message.OptionalFields)$
     /// <summary>
     /// Gets information about whether each optional field has been set.
     /// </summary>
@@ -66,7 +74,7 @@ $if(struct.OptionalFields)$
     }
 
 $endif$
-    $struct.Fields:generateField(); separator="\n\n"$
+    $message.Fields:generateField(); separator="\n\n"$
 
 $endif$
     /// <inheritdoc />
@@ -76,8 +84,8 @@ $endif$
 
         try
         {
-            $if(struct.RequiredFields)$
-            $struct.RequiredFields:declareIsSetVariable(); separator="\n"$
+            $if(message.RequiredFields)$
+            $message.RequiredFields:declareIsSetVariable(); separator="\n"$
 
             $endif$
             await protocol.ReadStructBeginAsync(cancellationToken);
@@ -92,8 +100,8 @@ $endif$
 
                 switch (field.ID)
                 {
-$if(struct.Fields)$
-                    $struct.Fields:{field | $generateReadFieldCaseStatement(field, typeMap)$}; separator="\n\n"$
+$if(message.Fields)$
+                    $message.Fields:{field | $generateReadFieldCaseStatement(field, typeMap)$}; separator="\n\n"$
 
 $endif$
                     default: 
@@ -106,9 +114,9 @@ $endif$
             }
 
             await protocol.ReadStructEndAsync(cancellationToken);
-            $if(struct.RequiredFields)$
+            $if(message.RequiredFields)$
 
-            $struct.RequiredFields:verifyRequiredFieldIsSet(); separator="\n\n"$
+            $message.RequiredFields:verifyRequiredFieldIsSet(); separator="\n\n"$
             $endif$
         }
         finally
@@ -124,12 +132,12 @@ $endif$
 
         try
         {
-            var @struct = new TStruct("$struct.Name$");
+            var @struct = new TStruct("$message.Name$");
             await protocol.WriteStructBeginAsync(@struct, cancellationToken);
-$if(struct.Fields)$
+$if(message.Fields)$
             var field = new TField();
 
-            $struct.Fields:{field | $generateWriteField(field, typeMap)$}; separator="\n\n"$
+            $message.Fields:{field | $generateWriteField(field, typeMap)$}; separator="\n\n"$
 
 $endif$      
             await protocol.WriteFieldStopAsync(cancellationToken);
@@ -140,24 +148,24 @@ $endif$
             protocol.DecrementRecursionDepth();
         }
     }
-$if(struct.Fields)$
+$if(message.Fields)$
 
     /// <inheritdoc />
     public override bool Equals(object obj)
     {
-        return obj is $struct.Name$ other && this.Equals(other);
+        return obj is $message.Name$ other && this.Equals(other);
     }
 
     /// <inheritdoc />
     public override int GetHashCode()
     {
         var hashCode = new HashCode();
-        $struct.Fields:{f | hashCode.Add(this.$f.Name$);}; separator="\n"$
+        $message.Fields:{f | hashCode.Add(this.$f.Name$);}; separator="\n"$
 
         return hashCode.ToHashCode();
     }
 
-    private bool Equals($struct.Name$ other)
+    private bool Equals($message.Name$ other)
     {
         if (object.ReferenceEquals(this, other))
         {
@@ -165,7 +173,7 @@ $if(struct.Fields)$
         }
 
         return other != null &&
-            $struct.Fields:generateEqualsComparison(); separator=" &&\n"$;
+            $message.Fields:generateEqualsComparison(); separator=" &&\n"$;
     }
 
     /// <summary>
@@ -174,10 +182,10 @@ $if(struct.Fields)$
     /// </summary>
     public static class FieldIds
     {
-        $struct.Fields:generateFieldId(); separator="\n\n"$
+        $message.Fields:generateFieldId(); separator="\n\n"$
     }
 $endif$
-$if(struct.OptionalFields)$
+$if(message.OptionalFields)$
 
     /// <summary>
     /// Contains an entry for each optional field, indicating whether it has been
@@ -185,7 +193,7 @@ $if(struct.OptionalFields)$
     /// </summary>
     public struct IsSetInfo
     {
-        $struct.OptionalFields:generateIsSetField(); separator="\n\n"$
+        $message.OptionalFields:generateIsSetField(); separator="\n\n"$
     }
 $endif$
 }

--- a/src/Thrift.Net.Tests/Compilation/Binding/ExceptionBinder/IdentifierTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Binding/ExceptionBinder/IdentifierTests.cs
@@ -1,0 +1,53 @@
+namespace Thrift.Net.Tests.Compilation.Binding.ExceptionBinder
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Symbols;
+    using Thrift.Net.Compilation.Symbols.Builders;
+    using Thrift.Net.Tests.Utility;
+    using Xunit;
+
+    public class IdentifierTests
+    {
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+
+        private readonly ExceptionBinder binder;
+
+        public IdentifierTests()
+        {
+            this.binder = new ExceptionBinder(this.binderProvider);
+        }
+
+        [Fact]
+        public void Bind_ExceptionNameSupplied_SetsName()
+        {
+            // Arrange
+            var document = new DocumentBuilder().Build();
+            var exceptionNode = ParserInput
+                .FromString("exception NotFoundException {}")
+                .ParseInput(parser => parser.exceptionDefinition());
+
+            // Act
+            var exception = this.binder.Bind<IException>(exceptionNode, document);
+
+            // Assert
+            Assert.Equal("NotFoundException", exception.Name);
+        }
+
+        [Fact]
+        public void Bind_ExceptionNameNotSupplied_Null()
+        {
+            // Arrange
+            var document = new DocumentBuilder().Build();
+            var exceptionNode = ParserInput
+                .FromString("exception {}")
+                .ParseInput(parser => parser.exceptionDefinition());
+
+            // Act
+            var exception = this.binder.Bind<IException>(exceptionNode, document);
+
+            // Assert
+            Assert.Null(exception.Name);
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Symbols/Document/AllTypesTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/Document/AllTypesTests.cs
@@ -95,5 +95,25 @@ struct Permission {}";
                 allTypes,
                 member => Assert.Same(union, member));
         }
+
+        [Fact]
+        public void ContainsException_IncludesException()
+        {
+            // Arrange
+            var input =
+@"exception NotFoundException {}";
+            var document = this.CreateDocumentFromInput(input);
+
+            var exception = this.SetupMember(
+                document.Node.definitions().exceptionDefinition()[0], "NotFoundException", document);
+
+            // Act
+            var allTypes = document.AllTypes;
+
+            // Assert
+            Assert.Collection(
+                allTypes,
+                member => Assert.Same(exception, member));
+        }
     }
 }

--- a/src/Thrift.Net.Tests/Compilation/Symbols/Document/DocumentTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/Document/DocumentTests.cs
@@ -54,6 +54,20 @@ namespace Thrift.Net.Tests.Compilation.Symbols.Document
             return member;
         }
 
+        protected IException SetupMember(ExceptionDefinitionContext node, string name, Document document)
+        {
+            var member = new ExceptionBuilder()
+                .SetNode(node)
+                .SetName(name)
+                .Build();
+
+            this.binderProvider.GetBinder(node).Returns(this.memberBinder);
+            this.memberBinder.Bind<INamedSymbol>(node, document).Returns(member);
+            this.memberBinder.Bind<IException>(node, document).Returns(member);
+
+            return member;
+        }
+
         protected Namespace SetupNamespace(NamespaceStatementContext namespaceNode, string scope, string name, Document document)
         {
             var @namespace = new NamespaceBuilder()

--- a/src/Thrift.Net.Tests/Compilation/Symbols/Document/ExceptionTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/Document/ExceptionTests.cs
@@ -1,0 +1,49 @@
+namespace Thrift.Net.Tests.Compilation.Symbols.Document
+{
+    using Xunit;
+
+    public class ExceptionTests : DocumentTests
+    {
+        [Fact]
+        public void DocumentHasNoExceptions_Empty()
+        {
+            // Arrange
+            var document = this.CreateDocumentFromInput(string.Empty);
+
+            // Act
+            var exceptions = document.Exceptions;
+
+            // Assert
+            Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public void ExceptionsProvided_SetsExceptions()
+        {
+            // Arrange
+            var input =
+@"exception User {}
+exception Address {}";
+            var document = this.CreateDocumentFromInput(input);
+
+            var notFoundException = this.SetupMember(
+                document.Node.definitions().exceptionDefinition()[0],
+                "NotFoundException",
+                document);
+
+            var invalidException = this.SetupMember(
+                document.Node.definitions().exceptionDefinition()[1],
+                "InvalidException",
+                document);
+
+            // Act
+            var exceptions = document.Exceptions;
+
+            // Assert
+            Assert.Collection(
+                exceptions,
+                notFound => Assert.Same(notFoundException, notFound),
+                invalid => Assert.Same(invalidException, invalid));
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Symbols/Exception/ExceptionTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/Exception/ExceptionTests.cs
@@ -1,0 +1,50 @@
+namespace Thrift.Net.Tests.Compilation.Symbols.Exception
+{
+    using NSubstitute;
+    using Thrift.Net.Compilation.Binding;
+    using Thrift.Net.Compilation.Symbols;
+    using Thrift.Net.Compilation.Symbols.Builders;
+    using Thrift.Net.Tests.Utility;
+    using static Thrift.Net.Antlr.ThriftParser;
+
+    public abstract class ExceptionTests
+    {
+        private readonly IBinder fieldBinder = Substitute.For<IBinder>();
+        private readonly IBinderProvider binderProvider = Substitute.For<IBinderProvider>();
+
+        protected IBinder FieldBinder => this.fieldBinder;
+        protected IBinderProvider BinderProvider => this.binderProvider;
+
+        protected Exception CreateExceptionFromInput(string input)
+        {
+            var node = ParserInput
+                .FromString(input)
+                .ParseInput(parser => parser.exceptionDefinition());
+
+            return new ExceptionBuilder()
+                .SetNode(node)
+                .SetBinderProvider(this.BinderProvider)
+                .Build();
+        }
+
+        protected Field SetupField(
+            FieldContext fieldNode,
+            Exception exception,
+            int? fieldId = null,
+            string name = null,
+            FieldRequiredness requiredness = FieldRequiredness.Default)
+        {
+            var field = new FieldBuilder()
+                .SetNode(fieldNode)
+                .SetFieldId(fieldId)
+                .SetRequiredness(requiredness)
+                .SetName(name)
+                .Build();
+
+            this.binderProvider.GetBinder(fieldNode).Returns(this.fieldBinder);
+            this.fieldBinder.Bind<Field>(fieldNode, exception).Returns(field);
+
+            return field;
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Symbols/Exception/FieldTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/Exception/FieldTests.cs
@@ -1,0 +1,31 @@
+namespace Thrift.Net.Tests.Compilation.Symbols.Exception
+{
+    using Xunit;
+
+    public class FieldTests : ExceptionTests
+    {
+        [Fact]
+        public void Bind_FieldsSupplied_UsesBinderToCreateFields()
+        {
+            // Arrange
+            var input =
+@"exception NotFoundException {
+    1: i32 Id
+    2: string Username
+}";
+            var exception = this.CreateExceptionFromInput(input);
+
+            var idField = this.SetupField(exception.Node.field()[0], exception);
+            var usernameField = this.SetupField(exception.Node.field()[1], exception);
+
+            // Act
+            var fields = exception.Fields;
+
+            // Assert
+            Assert.Collection(
+                fields,
+                id => Assert.Same(idField, id),
+                username => Assert.Same(usernameField, username));
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/Symbols/Exception/OptionalFieldTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/Exception/OptionalFieldTests.cs
@@ -1,0 +1,34 @@
+namespace Thrift.Net.Tests.Compilation.Symbols.Exception
+{
+    using Thrift.Net.Compilation.Symbols;
+    using Xunit;
+
+    public class OptionalFieldTests : ExceptionTests
+    {
+        [Fact]
+        public void HasOptionalFields_ReturnsOptionalFields()
+        {
+            // Arrange
+            var input =
+@"exception User {
+    1: i32 DefaultField
+    2: required i32 RequiredField
+    3: required i32 OptionalField
+}";
+            var exception = this.CreateExceptionFromInput(input);
+
+            var defaultField = this.SetupField(exception.Node.field()[0], exception, requiredness: FieldRequiredness.Default);
+            var requiredField = this.SetupField(exception.Node.field()[1], exception, requiredness: FieldRequiredness.Required);
+            var optionalField = this.SetupField(exception.Node.field()[2], exception, requiredness: FieldRequiredness.Optional);
+
+            // Act
+            var fields = exception.OptionalFields;
+
+            // Assert
+            Assert.Collection(
+                fields,
+                @default => Assert.Same(defaultField, @default),
+                optional => Assert.Same(optionalField, optional));
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ExceptionErrorTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ExceptionErrorTests.cs
@@ -1,0 +1,29 @@
+namespace Thrift.Net.Tests.Compilation.ThriftCompiler
+{
+    using Xunit;
+
+    public class ExceptionErrorTests : ThriftCompilerTests
+    {
+        [Fact]
+        public void ExceptionNameMissing_ReportsError()
+        {
+            this.AssertCompilerReturnsErrorMessage(
+@"$exception$ {
+    1: string Query
+}",
+Thrift.Net.Compilation.CompilerMessageId.ExceptionMustHaveAName);
+        }
+
+        [Fact]
+        public void ExceptionNameAlreadyUsed_ReportsError()
+        {
+            this.AssertCompilerReturnsErrorMessage(
+@"struct Request {}
+exception $Request$ {
+    1: string Query
+}",
+Thrift.Net.Compilation.CompilerMessageId.NameAlreadyDeclared,
+"Request");
+        }
+    }
+}

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ExceptionParsingTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ExceptionParsingTests.cs
@@ -6,49 +6,49 @@ namespace Thrift.Net.Tests.Compilation.ThriftCompiler
 
     using ThriftCompiler = Thrift.Net.Compilation.ThriftCompiler;
 
-    public class UnionParsingTests
+    public class ExceptionParsingTests
     {
         private readonly ThriftCompiler compiler = new ThriftCompiler();
 
         [Fact]
-        public void Compile_DocumentContainsUnion_AddsUnionToModel()
+        public void Compile_DocumentContainsException_AddsExceptionToModel()
         {
             // Arrange
-            var input = "union User {}";
+            var input = "exception NotFoundException {}";
 
             // Act
             var result = this.compiler.Compile(input.ToStream());
 
             // Assert
             Assert.Collection(
-                result.Document.Unions,
-                item => Assert.Equal("User", item.Name));
+                result.Document.Exceptions,
+                item => Assert.Equal("NotFoundException", item.Name));
         }
 
         [Fact]
-        public void Compile_DocumentContainsMultipleUnions_AddsAllToModel()
+        public void Compile_DocumentContainsMultipleExceptions_AddsAllToModel()
         {
             // Arrange
             var input =
-@"union User {}
-union Team {}";
+@"exception NotFoundException {}
+exception NotEnabledException {}";
 
             // Act
             var result = this.compiler.Compile(input.ToStream());
 
             // Assert
             Assert.Collection(
-                result.Document.Unions,
-                item => Assert.Equal("User", item.Name),
-                item => Assert.Equal("Team", item.Name));
+                result.Document.Exceptions,
+                item => Assert.Equal("NotFoundException", item.Name),
+                item => Assert.Equal("NotEnabledException", item.Name));
         }
 
         [Fact]
-        public void Compile_UnionContainsFields_AddsFieldsToUnion()
+        public void Compile_ExceptionContainsFields_AddsFieldsToException()
         {
             // Arrange
             var input =
-@"union User {
+@"exception NotFoundException {
     i32 Id
     string Name
 }";
@@ -57,7 +57,7 @@ union Team {}";
             var result = this.compiler.Compile(input.ToStream());
 
             // Assert
-            var definition = result.Document.Unions.First();
+            var definition = result.Document.Exceptions.First();
 
             Assert.Collection(
                 definition.Fields,
@@ -66,23 +66,23 @@ union Team {}";
         }
 
         [Fact]
-        public void Compile_UnionContainsFields_SetsFieldIdsCorrectly()
+        public void Compile_ExceptionContainsFields_SetsFieldIdsCorrectly()
         {
             // Arrange
             var input =
-@"union User {
+@"exception NotFoundException {
     i32 Id
     1: string Username
-    2: string CreatedOn
-    string Name
-    string DeletedOn
+    2: string Timestamp
+    string ErrorId
+    string Type
 }";
 
             // Act
             var result = this.compiler.Compile(input.ToStream());
 
             // Assert
-            var definition = result.Document.Unions.First();
+            var definition = result.Document.Exceptions.First();
 
             Assert.Collection(
                 definition.Fields,
@@ -94,11 +94,11 @@ union Team {}";
         }
 
         [Fact]
-        public void Compile_UnionUsesCommaFieldSeparators_ParsesCorrectly()
+        public void Compile_ExceptionUsesCommaFieldSeparators_ParsesCorrectly()
         {
             // Arrange
             var input =
-@"union User {
+@"exception NotFoundException {
     i32 Id,
     string Username
 }";
@@ -108,15 +108,15 @@ union Team {}";
 
             // Assert
             Assert.False(result.HasErrors);
-            Assert.Equal(2, result.Document.Unions.Single().Fields.Count());
+            Assert.Equal(2, result.Document.Exceptions.Single().Fields.Count());
         }
 
         [Fact]
-        public void Compile_UnionUsesSemicolonFieldSeparators_ParsesCorrectly()
+        public void Compile_ExceptionUsesSemicolonFieldSeparators_ParsesCorrectly()
         {
             // Arrange
             var input =
-@"union User {
+@"exception NotFoundException {
     i32 Id;
     string Username
 }";
@@ -126,32 +126,32 @@ union Team {}";
 
             // Assert
             Assert.False(result.HasErrors);
-            Assert.Equal(2, result.Document.Unions.Single().Fields.Count());
+            Assert.Equal(2, result.Document.Exceptions.Single().Fields.Count());
         }
 
         [Fact]
-        public void Compile_MultipleUnions_AssignsFieldsToCorrectUnion()
+        public void Compile_MultipleExceptions_AssignsFieldsToCorrectException()
         {
             // Arrange
             var input =
-@"union User {
+@"exception NotFoundException {
     1: i32 Id
     2: string Username
 }
 
-union Address {
-    1: string Line1
-    2: string Line2
-    3: string Town
+exception OperationFailedException {
+    1: string Operation
+    2: string Timestamp
+    3: string Details
 }";
 
             // Act
             var result = this.compiler.Compile(input.ToStream());
 
             // Assert
-            Assert.Equal(2, result.Document.Unions.Count);
-            Assert.Equal(2, result.Document.Unions.ElementAt(0).Fields.Count);
-            Assert.Equal(3, result.Document.Unions.ElementAt(1).Fields.Count);
+            Assert.Equal(2, result.Document.Exceptions.Count);
+            Assert.Equal(2, result.Document.Exceptions.ElementAt(0).Fields.Count);
+            Assert.Equal(3, result.Document.Exceptions.ElementAt(1).Fields.Count);
         }
     }
 }

--- a/thrift-samples/exceptions/NotFoundException.thrift
+++ b/thrift-samples/exceptions/NotFoundException.thrift
@@ -1,0 +1,12 @@
+namespace netstd Thrift.Net.Examples.Exceptions
+
+enum ObjectType {
+    User = 0
+    Order = 1
+}
+
+exception NotFoundException {
+    1: ObjectType Type
+    2: string Id
+    3: string Message
+}

--- a/thrift-samples/exceptions/comparison.thrift
+++ b/thrift-samples/exceptions/comparison.thrift
@@ -1,0 +1,9 @@
+namespace netstd Thrift.Net.Examples.Exceptions
+
+struct Struct {
+    1: i32 Field1
+}
+
+exception Exception {
+    1: i32 Field1
+}

--- a/thrift-samples/exceptions/errors.thrift
+++ b/thrift-samples/exceptions/errors.thrift
@@ -1,0 +1,11 @@
+namespace netstd Thrift.Net.Examples.Exceptions
+
+exception {
+    1: string First
+    2: optional string Second
+    3: required string Third
+    i32 Fifth
+}
+
+struct Request {}
+exception Request {}

--- a/thrift-samples/unions/comparison.thrift
+++ b/thrift-samples/unions/comparison.thrift
@@ -1,0 +1,13 @@
+namespace netstd Thrift.Net.Examples.Unions
+
+struct Struct {
+    1: string First
+    2: string Second
+    3: optional i32 OptionalField
+}
+
+union Union {
+    1: string First
+    2: string Second
+    3: optional i32 OptionalField
+}


### PR DESCRIPTION
- Added the ability to parse and generate exceptions.
- Added a git ignore for a 'TODO' file since it's handy to have a file to add notes to while working
  that won't be committed.
- Refactored `Document.Children` to use `AllTypes` to avoid having to update both places as new
  member types are added.
- Renamed the `struct` parameter in `generateMessage` in the code generation template to `message`
  since it can be a Struct, Union or an Exception.

Part of #13