### PR TITLE
feat(compiler): support for byte constants

### DIFF
--- a/src/Thrift.Net.Compilation/Symbols/BaseType.cs
+++ b/src/Thrift.Net.Compilation/Symbols/BaseType.cs
@@ -202,7 +202,7 @@ namespace Thrift.Net.Compilation.Symbols
             return node.typeName.Text switch
             {
                 BoolName => new BaseType(node, parent, BoolName, "bool", "bool?"),
-                ByteName => new BaseType(node, parent, ByteName, "byte", "byte?"),
+                ByteName => new BaseType(node, parent, ByteName, "sbyte", "sbyte?"),
                 I8Name => new BaseType(node, parent, I8Name, "sbyte", "sbyte?"),
                 I16Name => new BaseType(node, parent, I16Name, "short", "short?"),
                 I32Name => new BaseType(node, parent, I32Name, "int", "int?"),
@@ -231,7 +231,7 @@ namespace Thrift.Net.Compilation.Symbols
             // NOTE: At the moment we're checking the type names. Once we separate
             // out the concept of a type vs a type reference, and we only have a single
             // instance of each base type, we can switch to using reference equality instead.
-            if (this.Name == I8Name && expressionType.Name == I8Name)
+            if (this.Name == I8Name && (expressionType.Name == I8Name || expressionType.Name == ByteName))
             {
                 return true;
             }
@@ -252,6 +252,13 @@ namespace Thrift.Net.Compilation.Symbols
             }
 
             if (this.Name == DoubleName && (expressionType.Name == I8Name || expressionType.Name == I16Name || expressionType.Name == I32Name || expressionType.Name == I64Name))
+            {
+                return true;
+            }
+
+            // `byte` has been superceded by the `i8` type and is equivalent, so an `i8` can
+            // be assigned to a `byte`.
+            if (this.Name == ByteName && (expressionType.Name == I8Name || expressionType.Name == ByteName))
             {
                 return true;
             }

--- a/src/Thrift.Net.Tests/Compilation/Symbols/BaseType/BaseTypeTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/Symbols/BaseType/BaseTypeTests.cs
@@ -23,7 +23,7 @@ namespace Thrift.Net.Tests.Compilation.Symbols.BaseType
                 new object[] { BaseType.I8, BaseType.Double, false },
                 new object[] { BaseType.I8, BaseType.String, false },
                 new object[] { BaseType.I8, BaseType.Bool, false },
-                new object[] { BaseType.I8, BaseType.Byte, false },
+                new object[] { BaseType.I8, BaseType.Byte, true },
                 new object[] { BaseType.I8, BaseType.Binary, false },
                 new object[] { BaseType.I8, BaseType.Slist, false },
 
@@ -100,7 +100,7 @@ namespace Thrift.Net.Tests.Compilation.Symbols.BaseType
                 new object[] { BaseType.Bool, BaseType.Slist, false },
 
                 // byte
-                new object[] { BaseType.Byte, BaseType.I8, false },
+                new object[] { BaseType.Byte, BaseType.I8, true },
                 new object[] { BaseType.Byte, BaseType.I16, false },
                 new object[] { BaseType.Byte, BaseType.I32, false },
                 new object[] { BaseType.Byte, BaseType.I64, false },
@@ -139,7 +139,7 @@ namespace Thrift.Net.Tests.Compilation.Symbols.BaseType
 
         [Theory]
         [InlineData("bool", "bool", "bool?")]
-        [InlineData("byte", "byte", "byte?")]
+        [InlineData("byte", "sbyte", "sbyte?")]
         [InlineData("i8", "sbyte", "sbyte?")]
         [InlineData("i16", "short", "short?")]
         [InlineData("i32", "int", "int?")]


### PR DESCRIPTION
- Added support for generating `byte` constants. Previously it wasn't possible because we didn't
  allow `i8` constant expressions to be assigned to fields of type `byte`.
- Changed the C# type that gets generated for a Thrift `byte` from `byte` to `sbyte` to match the i8
  type. I've realised this is what the official compiler does.

Issues: #8
