### PR TITLE
feat(compiler): add error for binary constants

### DIFF
--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -150,3 +150,33 @@ thrift-samples/structs/User.thrift(9,5-5): Error TC0203: Field Id '0' is not val
 **NOTE:** the official compiler supports a command-line argument to allow
 non-positive field Ids. At the moment we are taking the decision not to support
 this option unless someone requests it.
+
+### Binary Constants
+
+The official compiler allows you to declare a constant using the `binary` type,
+but it's not clear how a binary field could be initialised based on the
+available constant expressions defined in the Thrift IDL.
+
+The official compiler will allow a string literal to be assigned to a binary
+constant:
+
+```thrift
+const binary Blob = "testing123"
+```
+
+But the resulting C# code doesn't compile:
+
+```csharp
+public const byte[] Blob = "testing123";
+```
+
+As a result we've taken the decision to output an error message if a constant is
+declared using the binary type:
+
+```shell
+Error TC0804: 'Blob' has been declared using the `binary` type, which is not supported for constants. Please change the type of your constant.
+```
+
+This should highlight it as a problem if anyone is actually using binary
+constants, and we can then implement it properly. In the meantime it should
+prevent code being generated that can't be compiled.

--- a/src/Thrift.Net.Compilation/CompilationVisitor.cs
+++ b/src/Thrift.Net.Compilation/CompilationVisitor.cs
@@ -444,6 +444,15 @@ namespace Thrift.Net.Compilation
                     constant.Type.Name);
             }
 
+            if (constant.Type.Name == BaseType.BinaryName)
+            {
+                this.AddError(
+                    CompilerMessageId.BinaryConstantNotSupported,
+                    constant.Node.fieldType().Start,
+                    constant.Node.fieldType().Stop,
+                    constant.Name);
+            }
+
             base.VisitConstant(constant);
         }
 

--- a/src/Thrift.Net.Compilation/CompilerMessageId.cs
+++ b/src/Thrift.Net.Compilation/CompilerMessageId.cs
@@ -837,5 +837,23 @@ namespace Thrift.Net.Compilation
         /// </code>
         /// </example>
         ConstantExpressionCannotBeAssignedToType = 803,
+
+        /// <summary>
+        /// A constant has been declared using the `binary` type, which isn't supported
+        /// for constant expressions.
+        /// </summary>
+        /// <example>
+        /// The following example produces this error:
+        /// <code>
+        /// const binary Blob = "100"
+        ///       ^^^^^^
+        /// </code>
+        ///
+        /// To resolve this issue, change the type of the constant.
+        /// <code>
+        /// const string Blob = "100"
+        /// </code>
+        /// </example>
+        BinaryConstantNotSupported = 804,
     }
 }

--- a/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
+++ b/src/Thrift.Net.Compilation/Resources/CompilerMessages.resx
@@ -176,4 +176,7 @@
   <data name="TC0803" xml:space="preserve">
     <value>The expression '{0}' cannot be assigned to a constant of type '{1}'. Please check your expression and constant are of the correct type.</value>
   </data>
+  <data name="TC0804" xml:space="preserve">
+    <value>'{0}' has been declared using the `binary` type, which is not supported for constants. Please change the type of your constant.</value>
+  </data>
 </root>

--- a/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ConstantErrorTests.cs
+++ b/src/Thrift.Net.Tests/Compilation/ThriftCompiler/ConstantErrorTests.cs
@@ -64,5 +64,14 @@ namespace Thrift.Net.Tests.Compilation.ThriftCompiler
                 expression,
                 constantType);
         }
+
+        [Fact]
+        public void BinaryConstantDefined_ReportsError()
+        {
+            this.AssertCompilerReturnsErrorMessage(
+                "const $binary$ Blob = \"testing123\"",
+                CompilerMessageId.BinaryConstantNotSupported,
+                "Blob");
+        }
     }
 }


### PR DESCRIPTION
- Added a new error message if a constant is declared using the `binary` type. It's possible that
  binary is supported for constants, but I couldn't find any documentation about it, and I couldn't
  think how it would be initialised based on the supported constant expressions. The Apache compiler
  allows string literals to be assigned to `binary` constants, but the resulting code doesn't
  compile.
- Added an explanation of this behaviour along with the rationale to the compilation.md document.

Issues: #8
